### PR TITLE
Reduced success logs to only be printed for files that actually contain machines

### DIFF
--- a/.changeset/twelve-sheep-care.md
+++ b/.changeset/twelve-sheep-care.md
@@ -1,0 +1,5 @@
+---
+"@xstate/cli": patch
+---
+
+Reduced success logs to only be printed for files that actually contain machines.

--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -33,6 +33,11 @@ const writeToFiles = async (uriArray: string[]) => {
       try {
         const fileContents = await fs.readFile(uri, "utf8");
         const parseResult = parseMachinesFromFile(fileContents);
+
+        if (!parseResult.machines.length) {
+          return
+        }
+
         const event = makeXStateUpdateEvent(
           uri,
           parseResult.machines.map((machine) => ({


### PR DESCRIPTION
Related to https://github.com/statelyai/xstate-tools/issues/92