### PR TITLE
Fix parser to include description from transition object

### DIFF
--- a/.changeset/clever-years-exist.md
+++ b/.changeset/clever-years-exist.md
@@ -1,0 +1,6 @@
+---
+"@xstate/machine-extractor": patch
+"stately-vscode": patch
+---
+
+Fixed a bug where transition descriptions would not be picked up when parsing the code for sending to the visual editor.

--- a/.changeset/fast-taxis-walk.md
+++ b/.changeset/fast-taxis-walk.md
@@ -1,0 +1,6 @@
+---
+"@xstate/machine-extractor": patch
+"stately-vscode": patch
+---
+
+Fixed a bug where descriptions on transitions were not being visualised in VSCode.

--- a/packages/machine-extractor/examples/transition-description.machine.ts
+++ b/packages/machine-extractor/examples/transition-description.machine.ts
@@ -1,30 +1,30 @@
 import { createMachine } from "xstate";
 
 export const transitionDescription = createMachine({
-	id: "TransitionDescriptionMachine",
-	type: "parallel",
-	states: {
-		Ticket: {
-			initial: "Open",
-			states: {
-				Open: {
-					on: {
-						cancel: {
-							actions: "cancel ticket",
-							target: "Canceled",
-							description: "This is description example",
-						},
-						secondCancel: {
+  id: "TransitionDescriptionMachine",
+  type: "parallel",
+  states: {
+    Ticket: {
+      initial: "Open",
+      states: {
+        Open: {
+          on: {
+            cancel: {
+              actions: "cancel ticket",
+              target: "Canceled",
+              description: "This is description example",
+            },
+            secondCancel: {
               actions: "Secondary cancel ticket",
               description: 
-								`This is the
-								second example`,
+                `This is the
+                second example`,
               target: "Canceled",
             },
-					},
-				},
-				Canceled: {},
-			},
-		},
-	},
+          },
+        },
+        Canceled: {},
+      },
+    },
+  },
 });

--- a/packages/machine-extractor/examples/transition-description.machine.ts
+++ b/packages/machine-extractor/examples/transition-description.machine.ts
@@ -1,0 +1,23 @@
+import { createMachine } from "xstate";
+
+export const transitionDescription = createMachine({
+	id: "TransitionDescriptionMachine",
+	type: "parallel",
+	states: {
+		Ticket: {
+			initial: "Open",
+			states: {
+				Open: {
+					on: {
+						cancel: {
+							actions: "cancel ticket",
+							target: "Canceled",
+							description: "This is description example",
+						},
+					},
+				},
+				Canceled: {},
+			},
+		},
+	},
+});

--- a/packages/machine-extractor/examples/transition-description.machine.ts
+++ b/packages/machine-extractor/examples/transition-description.machine.ts
@@ -1,23 +1,30 @@
 import { createMachine } from "xstate";
 
 export const transitionDescription = createMachine({
-  id: "TransitionDescriptionMachine",
-  type: "parallel",
-  states: {
-    Ticket: {
-      initial: "Open",
-      states: {
-        Open: {
-          on: {
-            cancel: {
-              actions: "cancel ticket",
+	id: "TransitionDescriptionMachine",
+	type: "parallel",
+	states: {
+		Ticket: {
+			initial: "Open",
+			states: {
+				Open: {
+					on: {
+						cancel: {
+							actions: "cancel ticket",
+							target: "Canceled",
+							description: "This is description example",
+						},
+						secondCancel: {
+              actions: "Secondary cancel ticket",
+              description: 
+								`This is the
+								second example`,
               target: "Canceled",
-              description: "This is description example",
             },
-          },
-        },
-        Canceled: {},
-      },
-    },
-  },
+					},
+				},
+				Canceled: {},
+			},
+		},
+	},
 });

--- a/packages/machine-extractor/examples/transition-description.machine.ts
+++ b/packages/machine-extractor/examples/transition-description.machine.ts
@@ -1,23 +1,23 @@
 import { createMachine } from "xstate";
 
 export const transitionDescription = createMachine({
-	id: "TransitionDescriptionMachine",
-	type: "parallel",
-	states: {
-		Ticket: {
-			initial: "Open",
-			states: {
-				Open: {
-					on: {
-						cancel: {
-							actions: "cancel ticket",
-							target: "Canceled",
-							description: "This is description example",
-						},
-					},
-				},
-				Canceled: {},
-			},
-		},
-	},
+  id: "TransitionDescriptionMachine",
+  type: "parallel",
+  states: {
+    Ticket: {
+      initial: "Open",
+      states: {
+        Open: {
+          on: {
+            cancel: {
+              actions: "cancel ticket",
+              target: "Canceled",
+              description: "This is description example",
+            },
+          },
+        },
+        Canceled: {},
+      },
+    },
+  },
 });

--- a/packages/machine-extractor/src/toMachineConfig.ts
+++ b/packages/machine-extractor/src/toMachineConfig.ts
@@ -225,6 +225,9 @@ export const getTransitions = (
     if (transition?.actions) {
       toPush.actions = getActionConfig(transition.actions, opts);
     }
+    if (transition?.description) {
+      toPush.description = transition?.description.value;
+    }
 
     transitions.push(toPush);
   });

--- a/packages/machine-extractor/src/transitions.ts
+++ b/packages/machine-extractor/src/transitions.ts
@@ -22,7 +22,7 @@ const TransitionObject = objectTypeWithKnownKeys({
   target: TransitionTarget,
   actions: MaybeArrayOfActions,
   cond: Cond,
-  description: StringLiteral,
+  description: unionType([StringLiteral, TemplateLiteral]),
 });
 
 const TransitionConfigOrTargetLiteral = unionType([

--- a/packages/machine-extractor/src/transitions.ts
+++ b/packages/machine-extractor/src/transitions.ts
@@ -22,6 +22,7 @@ const TransitionObject = objectTypeWithKnownKeys({
   target: TransitionTarget,
   actions: MaybeArrayOfActions,
   cond: Cond,
+  description: StringLiteral,
 });
 
 const TransitionConfigOrTargetLiteral = unionType([


### PR DESCRIPTION
Fix transition parser to include description field.

Currently, when we give description to a transition, it won't be parsed and shown in the editor.
This PR will fix the issue like the screenshot below:

<img width="1478" alt="Screenshot 2022-03-31 at 3 13 55 PM" src="https://user-images.githubusercontent.com/23502245/160998769-dbffaa21-2797-4c80-b5ea-16d20be2ac92.png">
