### PR TITLE
refactor: :technologist: enable test to run on non-Mac machines

### DIFF
--- a/apps/cli/src/__tests__/examples.test.ts
+++ b/apps/cli/src/__tests__/examples.test.ts
@@ -1,12 +1,15 @@
 import { execSync } from "child_process";
 import * as path from "path";
+import * as fs from "fs";
+import * as minimatch from "minimatch";
 
 describe("typegen", () => {
-  execSync("rm -rf ./__examples__/*.typegen.ts", {
-    cwd: __dirname,
-  });
-
   const examplesPath = path.resolve(__dirname, "__examples__");
+  const examplesFiles = fs.readdirSync(examplesPath);
+
+  minimatch
+    .match(examplesFiles, "*.typegen.ts")
+    .map((file) => fs.unlinkSync(path.join(examplesPath, file)));
 
   execSync("yarn build", {
     cwd: __dirname,

--- a/packages/shared/src/__tests__/getTypegenOutput.test.ts
+++ b/packages/shared/src/__tests__/getTypegenOutput.test.ts
@@ -6,15 +6,17 @@ import {
   getTypegenOutput,
   makeXStateUpdateEvent,
 } from "..";
+import * as minimatch from "minimatch";
 
 describe("getTypegenOutput", () => {
-  execSync("rm -rf ./__examples__/*.typegen.ts", {
-    cwd: __dirname,
-  });
+  const examplesPath = path.resolve(__dirname, "__examples__");
+  const examplesFiles = fs.readdirSync(examplesPath);
 
-  const dir = fs.readdirSync(path.resolve(__dirname, "__examples__"));
+  minimatch
+    .match(examplesFiles, "*.typegen.ts")
+    .map((file) => fs.unlinkSync(path.join(examplesPath, file)));
 
-  const tsExtensionFiles = dir.filter((file) => file.endsWith(".ts"));
+  const tsExtensionFiles = examplesFiles.filter((file) => file.endsWith(".ts"));
 
   tsExtensionFiles.forEach((file) => {
     const fileText = fs.readFileSync(


### PR DESCRIPTION
Currently Windows users cannot run the test suite because of platform specific code (`rm`)

This PR aims to improve the developer experience for Windows users