### PR TITLE
Added extraction for createTestMachine

### DIFF
--- a/.changeset/sour-phones-rush.md
+++ b/.changeset/sour-phones-rush.md
@@ -1,0 +1,7 @@
+---
+"@xstate/machine-extractor": minor
+"@xstate/cli": minor
+"stately-vscode": minor
+---
+
+Added parsing for the `@xstate/test` `createTestMachine` function

--- a/packages/machine-extractor/src/__tests__/createTestMachine.test.ts
+++ b/packages/machine-extractor/src/__tests__/createTestMachine.test.ts
@@ -1,0 +1,11 @@
+import { parseMachinesFromFile } from "../parseMachinesFromFile";
+
+it("Should handle createTestMachine", () => {
+  const machines = parseMachinesFromFile(`
+  	createTestMachine({});
+  `);
+
+  const result = machines.machines[0];
+
+  expect(result).toBeTruthy();
+});

--- a/packages/machine-extractor/src/machineCallExpression.ts
+++ b/packages/machine-extractor/src/machineCallExpression.ts
@@ -9,13 +9,19 @@ export type TMachineCallExpression = GetParserResult<
   typeof MachineCallExpression
 >;
 
+export const ALLOWED_CALL_EXPRESSION_NAMES = [
+  "createMachine",
+  "Machine",
+  "createTestMachine",
+];
+
 export const MachineCallExpression = createParser({
   babelMatcher: t.isCallExpression,
   parseNode: (node, context) => {
     if (
       t.isMemberExpression(node.callee) &&
       t.isIdentifier(node.callee.property) &&
-      ["createMachine", "Machine"].includes(node.callee.property.name)
+      ALLOWED_CALL_EXPRESSION_NAMES.includes(node.callee.property.name)
     ) {
       return {
         callee: node.callee,
@@ -30,7 +36,7 @@ export const MachineCallExpression = createParser({
 
     if (
       t.isIdentifier(node.callee) &&
-      ["createMachine", "Machine"].includes(node.callee.name)
+      ALLOWED_CALL_EXPRESSION_NAMES.includes(node.callee.name)
     ) {
       return {
         callee: node.callee,

--- a/packages/machine-extractor/src/parseMachinesFromFile.ts
+++ b/packages/machine-extractor/src/parseMachinesFromFile.ts
@@ -9,7 +9,7 @@ import { hashedId } from "./utils";
 
 export const parseMachinesFromFile = (fileContents: string): ParseResult => {
   if (
-    ALLOWED_CALL_EXPRESSION_NAMES.some((name) => fileContents.includes(name))
+    !ALLOWED_CALL_EXPRESSION_NAMES.some((name) => fileContents.includes(name))
   ) {
     return {
       machines: [],

--- a/packages/machine-extractor/src/parseMachinesFromFile.ts
+++ b/packages/machine-extractor/src/parseMachinesFromFile.ts
@@ -1,15 +1,15 @@
-import { parse, Node, types as t, traverse } from "@babel/core";
-import { MachineConfig } from "xstate";
-import { MachineCallExpression } from "./machineCallExpression";
+import { Node, parse, traverse, types as t } from "@babel/core";
+import {
+  ALLOWED_CALL_EXPRESSION_NAMES,
+  MachineCallExpression,
+} from "./machineCallExpression";
 import { MachineParseResult } from "./MachineParseResult";
-import { toMachineConfig } from "./toMachineConfig";
 import { ParseResult } from "./types";
 import { hashedId } from "./utils";
 
 export const parseMachinesFromFile = (fileContents: string): ParseResult => {
   if (
-    !fileContents.includes("createMachine") &&
-    !fileContents.includes("Machine")
+    ALLOWED_CALL_EXPRESSION_NAMES.some((name) => fileContents.includes(name))
   ) {
     return {
       machines: [],
@@ -28,7 +28,7 @@ export const parseMachinesFromFile = (fileContents: string): ParseResult => {
         "jsx",
         ["decorators", { decoratorsBeforeExport: false }],
       ],
-    }
+    },
   }) as t.File;
 
   let result: ParseResult = {
@@ -68,7 +68,7 @@ export const parseMachinesFromFile = (fileContents: string): ParseResult => {
             ast,
             fileComments: result.comments,
             scope: path.scope,
-          }),
+          })
         );
       }
     },


### PR DESCRIPTION
This is important because we're adding `createTestMachine` as a new API and need to make sure the VSCode extension works with it.