### PR TITLE
Make it possible to hit breakpoints when debugging our VS Code extension

### DIFF
--- a/apps/extension/client/package.json
+++ b/apps/extension/client/package.json
@@ -90,7 +90,7 @@
     "test": "jest --passWithNoTests",
     "viz:build": "esbuild src/vizWebviewScript.ts --bundle --outfile=scripts/vizWebview.js",
     "editor:build": "esbuild src/editorWebviewScript.ts --bundle --outfile=scripts/editorWebview.js",
-    "build": "esbuild --bundle --platform=\"node\" src/extension.ts --outfile=dist/index.js --external:vscode --format=cjs"
+    "build": "esbuild --bundle --platform=\"node\" src/extension.ts --outfile=dist/index.js --external:vscode --format=cjs --sourcemap"
   },
   "dependencies": {
     "@types/lz-string": "^1.3.34",


### PR DESCRIPTION
It would be handy to be able to hit breakpoints when debugging our VS Code extension. The only thing needed to achieve this is adding the sources to our (es) code build.