### PR TITLE
Added learn more link to file nesting prompt

### DIFF
--- a/.changeset/eleven-toes-attend.md
+++ b/.changeset/eleven-toes-attend.md
@@ -1,0 +1,5 @@
+---
+"stately-vscode": patch
+---
+
+Added learn more link to file nesting prompt.

--- a/apps/extension/client/src/checkTypegenNesting.ts
+++ b/apps/extension/client/src/checkTypegenNesting.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { Uri } from "vscode";
 
 // More info on the patterns in this comment: https://github.com/statelyai/xstate-tools/pull/146#discussion_r889904447
 const typegenPatternKeys = ["*.ts", "*.tsx", "*.mts", "*.cts"];
@@ -143,11 +144,13 @@ export const handleTypegenNestingConfig = () => {
     // Show prompt if the user wants to nest typegen files but hasn't defined our pattern yet
     const enableOption = "Enable";
     const disableOption = "No, don't ask again";
+    const learnMoreOption = "Learn more";
     vscode.window
       .showInformationMessage(
         "Do you want to enable file nesting for XState typegen files?",
         enableOption,
-        disableOption
+        disableOption,
+        learnMoreOption
       )
       .then((choice) => {
         switch (choice) {
@@ -157,6 +160,11 @@ export const handleTypegenNestingConfig = () => {
           case disableOption:
             getXStateConfig().update("nestTypegenFiles", false, true);
             disableTypegenNesting();
+            break;
+          case learnMoreOption:
+            vscode.env.openExternal(
+              Uri.parse("https://stately.ai/blog/nesting-xstate-typegen-files")
+            );
             break;
         }
       });


### PR DESCRIPTION
We've received [some feedback](https://twitter.com/markbennett/status/1534996099840110594?s=21&t=TIpJ7H7BJy-Pf7EkvLiaMQ) that our file nesting popup could deserve a little polish.

So this PR adds a learn more link to our file nesting prompt:
<img width="481" alt="CleanShot 2022-06-15 at 11 04 50" src="https://user-images.githubusercontent.com/167574/173789179-d481d1f1-74ce-4546-96bf-026bd8987c2b.png">

If the user clicks the link we will open their browser to our own blog post on file nesting for typegen files: https://stately.ai/blog/nesting-xstate-typegen-files (currently [in review](https://github.com/statelyai/eng-blog/pull/87)). [Preview here](https://blog-88cw2ho0p-statelyai.vercel.app/blog/nesting-xstate-typegen-files).