### PR TITLE
Add tests for the fixed logic related to machine traversal in `introspectMachine`

### DIFF
--- a/.changeset/curvy-wombats-tickle.md
+++ b/.changeset/curvy-wombats-tickle.md
@@ -1,0 +1,10 @@
+---
+"@xstate/cli": patch
+"stately-vscode": patch
+"@xstate/tools-shared": patch
+---
+
+pr: #170
+commit: bd0972c
+
+Fixed a couple of issues with entry and exit actions not having the appropriate event types associated with them in the generated typegen information. Those issues were mainly related to actions defined on the "path" in the machine in between the source and target states.

--- a/packages/shared/src/__tests__/__examples__/entry-action-on-ancestor-of-targeted-descendant.ts
+++ b/packages/shared/src/__tests__/__examples__/entry-action-on-ancestor-of-targeted-descendant.ts
@@ -2,19 +2,20 @@ import { createMachine } from "xstate";
 
 createMachine({
   tsTypes:
-    {} as import("./entry-action-on-initial-state-of-targeted-ancestor.typegen").Typegen0,
+    {} as import("./entry-action-on-ancestor-of-targeted-descendant.typegen").Typegen0,
   initial: "a",
   states: {
     a: {
       on: {
-        GO_STRING: "b",
+        GO_STRING: "#c",
       },
     },
     b: {
+      entry: ["sayHello"],
       initial: "c",
       states: {
         c: {
-          entry: ["sayHello"],
+          id: "c",
         },
       },
     },

--- a/packages/shared/src/__tests__/__examples__/entry-action-on-state-between-lca-and-target.ts
+++ b/packages/shared/src/__tests__/__examples__/entry-action-on-state-between-lca-and-target.ts
@@ -1,0 +1,24 @@
+import { createMachine } from "xstate";
+
+createMachine({
+  tsTypes:
+    {} as import("./entry-action-on-state-between-lca-and-target.typegen").Typegen0,
+  entry: ["rootEntry"],
+  initial: "a",
+  states: {
+    a: {
+      on: {
+        FOO: "#b1",
+      },
+    },
+    b: {
+      entry: ["sayHello"],
+      initial: "b1",
+      states: {
+        b1: {
+          id: "b1",
+        },
+      },
+    },
+  },
+});

--- a/packages/shared/src/__tests__/__examples__/entry-action-root-external-transition.ts
+++ b/packages/shared/src/__tests__/__examples__/entry-action-root-external-transition.ts
@@ -1,0 +1,19 @@
+import { createMachine } from "xstate";
+
+// this behavior might change in v5 if we decide that root is not never exited when transitions are taken
+
+createMachine({
+  tsTypes:
+    {} as import("./entry-action-root-external-transition.typegen").Typegen0,
+  entry: ["rootEntry"],
+  on: {
+    FOO: "#b",
+  },
+  initial: "a",
+  states: {
+    a: {},
+    b: {
+      id: "b",
+    },
+  },
+});

--- a/packages/shared/src/__tests__/__examples__/exit-action-on-state-between-lca-and-source-state.ts
+++ b/packages/shared/src/__tests__/__examples__/exit-action-on-state-between-lca-and-source-state.ts
@@ -1,0 +1,24 @@
+import { createMachine } from "xstate";
+
+createMachine({
+  tsTypes:
+    {} as import("./exit-action-on-state-between-lca-and-source-state.typegen").Typegen0,
+  initial: "a",
+  exit: ["rootExit"],
+  states: {
+    a: {
+      exit: ["sayHello"],
+      initial: "a1",
+      states: {
+        a1: {
+          on: {
+            FOO: "#b",
+          },
+        },
+      },
+    },
+    b: {
+      id: "b",
+    },
+  },
+});

--- a/packages/shared/src/__tests__/__examples__/exit-action-root-external-transition.ts
+++ b/packages/shared/src/__tests__/__examples__/exit-action-root-external-transition.ts
@@ -1,0 +1,19 @@
+import { createMachine } from "xstate";
+
+// this behavior might change in v5 if we decide that root is not never exited when transitions are taken
+
+createMachine({
+  tsTypes:
+    {} as import("./exit-action-root-external-transition.typegen").Typegen0,
+  exit: ["rootExit"],
+  on: {
+    FOO: "#b",
+  },
+  initial: "a",
+  states: {
+    a: {},
+    b: {
+      id: "b",
+    },
+  },
+});

--- a/packages/shared/src/__tests__/__examples__/exit-action-within-ancestor-with-internal-transition.ts
+++ b/packages/shared/src/__tests__/__examples__/exit-action-within-ancestor-with-internal-transition.ts
@@ -1,0 +1,19 @@
+import { createMachine } from "xstate";
+
+createMachine({
+  initial: "a",
+  tsTypes:
+    {} as import("./exit-action-within-ancestor-with-internal-transition.typegen").Typegen0,
+  states: {
+    a: {
+      on: {
+        FOO: ".a2",
+      },
+      initial: "a1",
+      states: {
+        a1: { exit: "exitA1" },
+        a2: { exit: "exitA2" },
+      },
+    },
+  },
+});

--- a/packages/shared/src/__tests__/__snapshots__/getTypegenOutput.test.ts.snap
+++ b/packages/shared/src/__tests__/__snapshots__/getTypegenOutput.test.ts.snap
@@ -149,6 +149,33 @@ export interface Typegen0 {
 "
 `;
 
+exports[`getTypegenOutput entry-action-on-ancestor-of-targeted-descendant 1`] = `
+"// This file was automatically generated. Edits will be overwritten
+
+export interface Typegen0 {
+  "@@xstate/typegen": true;
+  internalEvents: {
+    "xstate.init": { type: "xstate.init" };
+  };
+  invokeSrcNameMap: {};
+  missingImplementations: {
+    actions: "sayHello";
+    services: never;
+    guards: never;
+    delays: never;
+  };
+  eventsCausingActions: {
+    sayHello: "GO_STRING";
+  };
+  eventsCausingServices: {};
+  eventsCausingGuards: {};
+  eventsCausingDelays: {};
+  matchesStates: "a" | "b" | "b.c" | { b?: "c" };
+  tags: never;
+}
+"
+`;
+
 exports[`getTypegenOutput entry-action-on-initial-state-of-targeted-ancestor 1`] = `
 "// This file was automatically generated. Edits will be overwritten
 
@@ -171,6 +198,61 @@ export interface Typegen0 {
   eventsCausingGuards: {};
   eventsCausingDelays: {};
   matchesStates: "a" | "b" | "b.c" | { b?: "c" };
+  tags: never;
+}
+"
+`;
+
+exports[`getTypegenOutput entry-action-on-state-between-lca-and-target 1`] = `
+"// This file was automatically generated. Edits will be overwritten
+
+export interface Typegen0 {
+  "@@xstate/typegen": true;
+  internalEvents: {
+    "xstate.init": { type: "xstate.init" };
+  };
+  invokeSrcNameMap: {};
+  missingImplementations: {
+    actions: "rootEntry" | "sayHello";
+    services: never;
+    guards: never;
+    delays: never;
+  };
+  eventsCausingActions: {
+    rootEntry: "xstate.init";
+    sayHello: "FOO";
+  };
+  eventsCausingServices: {};
+  eventsCausingGuards: {};
+  eventsCausingDelays: {};
+  matchesStates: "a" | "b" | "b.b1" | { b?: "b1" };
+  tags: never;
+}
+"
+`;
+
+exports[`getTypegenOutput entry-action-root-external-transition 1`] = `
+"// This file was automatically generated. Edits will be overwritten
+
+export interface Typegen0 {
+  "@@xstate/typegen": true;
+  internalEvents: {
+    "xstate.init": { type: "xstate.init" };
+  };
+  invokeSrcNameMap: {};
+  missingImplementations: {
+    actions: "rootEntry";
+    services: never;
+    guards: never;
+    delays: never;
+  };
+  eventsCausingActions: {
+    rootEntry: "FOO" | "xstate.init";
+  };
+  eventsCausingServices: {};
+  eventsCausingGuards: {};
+  eventsCausingDelays: {};
+  matchesStates: "a" | "b";
   tags: never;
 }
 "
@@ -344,6 +426,63 @@ export interface Typegen0 {
 "
 `;
 
+exports[`getTypegenOutput exit-action-on-state-between-lca-and-source-state 1`] = `
+"// This file was automatically generated. Edits will be overwritten
+
+export interface Typegen0 {
+  "@@xstate/typegen": true;
+  internalEvents: {
+    "xstate.stop": { type: "xstate.stop" };
+    "xstate.init": { type: "xstate.init" };
+  };
+  invokeSrcNameMap: {};
+  missingImplementations: {
+    actions: "rootExit" | "sayHello";
+    services: never;
+    guards: never;
+    delays: never;
+  };
+  eventsCausingActions: {
+    rootExit: "xstate.stop";
+    sayHello: "xstate.stop" | "FOO";
+  };
+  eventsCausingServices: {};
+  eventsCausingGuards: {};
+  eventsCausingDelays: {};
+  matchesStates: "a" | "a.a1" | "b" | { a?: "a1" };
+  tags: never;
+}
+"
+`;
+
+exports[`getTypegenOutput exit-action-root-external-transition 1`] = `
+"// This file was automatically generated. Edits will be overwritten
+
+export interface Typegen0 {
+  "@@xstate/typegen": true;
+  internalEvents: {
+    "xstate.stop": { type: "xstate.stop" };
+    "xstate.init": { type: "xstate.init" };
+  };
+  invokeSrcNameMap: {};
+  missingImplementations: {
+    actions: "rootExit";
+    services: never;
+    guards: never;
+    delays: never;
+  };
+  eventsCausingActions: {
+    rootExit: "xstate.stop" | "FOO";
+  };
+  eventsCausingServices: {};
+  eventsCausingGuards: {};
+  eventsCausingDelays: {};
+  matchesStates: "a" | "b";
+  tags: never;
+}
+"
+`;
+
 exports[`getTypegenOutput exit-action-within-ancestor-with-external-transition-outside-of-source 1`] = `
 "// This file was automatically generated. Edits will be overwritten
 
@@ -367,6 +506,35 @@ export interface Typegen0 {
   eventsCausingGuards: {};
   eventsCausingDelays: {};
   matchesStates: "a" | "a.b" | "c" | { a?: "b" };
+  tags: never;
+}
+"
+`;
+
+exports[`getTypegenOutput exit-action-within-ancestor-with-internal-transition 1`] = `
+"// This file was automatically generated. Edits will be overwritten
+
+export interface Typegen0 {
+  "@@xstate/typegen": true;
+  internalEvents: {
+    "xstate.stop": { type: "xstate.stop" };
+    "xstate.init": { type: "xstate.init" };
+  };
+  invokeSrcNameMap: {};
+  missingImplementations: {
+    actions: "exitA1" | "exitA2";
+    services: never;
+    guards: never;
+    delays: never;
+  };
+  eventsCausingActions: {
+    exitA1: "FOO" | "xstate.stop";
+    exitA2: "xstate.stop";
+  };
+  eventsCausingServices: {};
+  eventsCausingGuards: {};
+  eventsCausingDelays: {};
+  matchesStates: "a" | "a.a1" | "a.a2" | { a?: "a1" | "a2" };
   tags: never;
 }
 "


### PR DESCRIPTION
This is a followup to https://github.com/statelyai/xstate-tools/pull/170 