### PR TITLE
Settings to set the editor theme explicitly

### DIFF
--- a/.changeset/dirty-comics-wink.md
+++ b/.changeset/dirty-comics-wink.md
@@ -1,0 +1,5 @@
+---
+"stately-vscode": minor
+---
+
+Adds a setting to sync the visual editor theme with the VS Code theme

--- a/apps/extension/client/package.json
+++ b/apps/extension/client/package.json
@@ -81,6 +81,16 @@
           "type": "boolean",
           "default": true,
           "description": "Enable nesting the generated typegen files."
+        },
+        "xstate.theme": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "dark",
+            "light"
+          ],
+          "default": "auto",
+          "description": "Color theme for the visual editor. Auto syncs the vscode theme with the editor theme."
         }
       }
     }

--- a/apps/extension/client/src/editorWebviewScript.ts
+++ b/apps/extension/client/src/editorWebviewScript.ts
@@ -1,5 +1,6 @@
 import { ImplementationsMetadata } from "@xstate/tools-shared";
 import { compressToEncodedURIComponent } from "lz-string";
+
 import { assign, createMachine, interpret, MachineConfig } from "xstate";
 import { TokenInfo } from "./auth";
 
@@ -17,6 +18,7 @@ export interface WebViewMachineContext {
   token: TokenInfo | undefined;
   implementations: ImplementationsMetadata;
   baseUrl: string;
+  themeKind: "light" | "dark";
 }
 
 export type EditorWebviewScriptEvent =
@@ -29,6 +31,7 @@ export type EditorWebviewScriptEvent =
       token: TokenInfo;
       implementations: ImplementationsMetadata;
       baseUrl: string;
+      themeKind: any;
     }
   | {
       type: "NODE_SELECTED";
@@ -102,6 +105,7 @@ const machine = createMachine<WebViewMachineContext, EditorWebviewScriptEvent>(
         services: {},
       },
       baseUrl: "",
+      themeKind: "dark",
     },
     invoke: {
       src: () => (send) => {
@@ -155,6 +159,7 @@ const machine = createMachine<WebViewMachineContext, EditorWebviewScriptEvent>(
                 token: event.token,
                 implementations: event.implementations,
                 baseUrl: event.baseUrl,
+                themeKind: event.themeKind,
               };
             }),
             internal: false,
@@ -176,7 +181,9 @@ const machine = createMachine<WebViewMachineContext, EditorWebviewScriptEvent>(
              * */
             iframe.src = `${
               context.baseUrl
-            }/registry/editor/from-url?runningInStatelyExtension=true&config=${compressToEncodedURIComponent(
+            }/registry/editor/from-url?runningInStatelyExtension=true&themeKind=${
+              context.themeKind
+            }&config=${compressToEncodedURIComponent(
               JSON.stringify(context.config)
             )}${
               context.layoutString ? `&layout=${context.layoutString}` : ""
@@ -197,6 +204,7 @@ const machine = createMachine<WebViewMachineContext, EditorWebviewScriptEvent>(
                   token: event.token,
                   implementations: event.implementations,
                   baseUrl: event.baseUrl,
+                  themeKind: event.themeKind,
                 };
               }),
               "updateIframe",

--- a/apps/extension/client/src/initiateEditor.ts
+++ b/apps/extension/client/src/initiateEditor.ts
@@ -8,6 +8,7 @@ import {
 } from "@xstate/tools-shared";
 import * as path from "path";
 import * as vscode from "vscode";
+import { ColorThemeKind } from "vscode";
 import type { LanguageClient } from "vscode-languageclient/node";
 import { MachineConfig } from "xstate";
 import { getAuth, SignInResult } from "./auth";
@@ -64,6 +65,16 @@ export const initiateEditor = (
       return;
     }
 
+    const settingsTheme =
+      vscode.workspace
+        .getConfiguration("xstate")
+        .get<"auto" | "dark" | "light">("theme") ?? "auto";
+    const themeKind =
+      settingsTheme === "auto"
+        ? vscode.window.activeColorTheme.kind === ColorThemeKind.Dark
+          ? "dark"
+          : "light"
+        : settingsTheme;
     if (currentPanel) {
       currentPanel.reveal(vscode.ViewColumn.Beside);
 
@@ -76,6 +87,7 @@ export const initiateEditor = (
         token: result,
         implementations,
         baseUrl,
+        themeKind,
       });
     } else {
       currentPanel = vscode.window.createWebviewPanel(
@@ -102,6 +114,7 @@ export const initiateEditor = (
         token: result,
         implementations,
         baseUrl,
+        themeKind,
       });
 
       currentPanel.webview.onDidReceiveMessage(


### PR DESCRIPTION
Three values are available now in the settings.
Auto means we read the theme kind from the vscode theme and sync that with the editor theme.
Dark means we always render the editor in the dark theme.
Light means we always render the editor in the light theme.
No support for high contract themes yet as the editor doesn't have that concept.