### PR TITLE
Sort keys and generated unions in the typegen output

### DIFF
--- a/packages/shared/src/__tests__/__snapshots__/getTypegenOutput.test.ts.snap
+++ b/packages/shared/src/__tests__/__snapshots__/getTypegenOutput.test.ts.snap
@@ -16,10 +16,10 @@ export interface Typegen0 {
     delays: never;
   };
   eventsCausingActions: {
-    someAction: "xstate.init";
-    otherAction: "xstate.init";
-    notImplementedYet: "xstate.init";
     anotherNotImplementedYet: "xstate.init";
+    notImplementedYet: "xstate.init";
+    otherAction: "xstate.init";
+    someAction: "xstate.init";
   };
   eventsCausingServices: {};
   eventsCausingGuards: {};
@@ -133,10 +133,10 @@ export interface Typegen0 {
     delays: never;
   };
   eventsCausingActions: {
-    wow: "FOO";
     a: "FOO";
     b: "FOO";
     c: "FOO";
+    wow: "FOO";
   };
   eventsCausingServices: {};
   eventsCausingGuards: {
@@ -274,8 +274,8 @@ export interface Typegen0 {
     delays: never;
   };
   eventsCausingActions: {
-    someAction: "FOO";
     otherAction: "BAR";
+    someAction: "FOO";
   };
   eventsCausingServices: {};
   eventsCausingGuards: {};
@@ -302,9 +302,9 @@ export interface Typegen0 {
     delays: never;
   };
   eventsCausingActions: {
-    rootEntry: "FOO" | "xstate.init";
-    entryA1: "FOO" | "xstate.init";
     entryA: "FOO" | "xstate.init";
+    entryA1: "FOO" | "xstate.init";
+    rootEntry: "FOO" | "xstate.init";
   };
   eventsCausingServices: {};
   eventsCausingGuards: {};
@@ -349,8 +349,8 @@ exports[`getTypegenOutput exit-action-external-transition-out-of-source 1`] = `
 export interface Typegen0 {
   "@@xstate/typegen": true;
   internalEvents: {
-    "xstate.stop": { type: "xstate.stop" };
     "xstate.init": { type: "xstate.init" };
+    "xstate.stop": { type: "xstate.stop" };
   };
   invokeSrcNameMap: {};
   missingImplementations: {
@@ -360,7 +360,7 @@ export interface Typegen0 {
     delays: never;
   };
   eventsCausingActions: {
-    doSomethingWithFoo: "xstate.stop" | "FOO";
+    doSomethingWithFoo: "FOO" | "xstate.stop";
   };
   eventsCausingServices: {};
   eventsCausingGuards: {};
@@ -377,8 +377,8 @@ exports[`getTypegenOutput exit-action-external-transition-within-source 1`] = `
 export interface Typegen0 {
   "@@xstate/typegen": true;
   internalEvents: {
-    "xstate.stop": { type: "xstate.stop" };
     "xstate.init": { type: "xstate.init" };
+    "xstate.stop": { type: "xstate.stop" };
   };
   invokeSrcNameMap: {};
   missingImplementations: {
@@ -405,8 +405,8 @@ exports[`getTypegenOutput exit-action-internal-transition 1`] = `
 export interface Typegen0 {
   "@@xstate/typegen": true;
   internalEvents: {
-    "xstate.stop": { type: "xstate.stop" };
     "xstate.init": { type: "xstate.init" };
+    "xstate.stop": { type: "xstate.stop" };
   };
   invokeSrcNameMap: {};
   missingImplementations: {
@@ -433,8 +433,8 @@ exports[`getTypegenOutput exit-action-on-ancestor-with-external-transition-on-de
 export interface Typegen0 {
   "@@xstate/typegen": true;
   internalEvents: {
-    "xstate.stop": { type: "xstate.stop" };
     "xstate.init": { type: "xstate.init" };
+    "xstate.stop": { type: "xstate.stop" };
   };
   invokeSrcNameMap: {};
   missingImplementations: {
@@ -444,7 +444,7 @@ export interface Typegen0 {
     delays: never;
   };
   eventsCausingActions: {
-    doSomethingWithFoo: "xstate.stop" | "FOO";
+    doSomethingWithFoo: "FOO" | "xstate.stop";
   };
   eventsCausingServices: {};
   eventsCausingGuards: {};
@@ -461,8 +461,8 @@ exports[`getTypegenOutput exit-action-on-state-between-lca-and-source-state 1`] 
 export interface Typegen0 {
   "@@xstate/typegen": true;
   internalEvents: {
-    "xstate.stop": { type: "xstate.stop" };
     "xstate.init": { type: "xstate.init" };
+    "xstate.stop": { type: "xstate.stop" };
   };
   invokeSrcNameMap: {};
   missingImplementations: {
@@ -473,7 +473,7 @@ export interface Typegen0 {
   };
   eventsCausingActions: {
     rootExit: "xstate.stop";
-    sayHello: "xstate.stop" | "FOO";
+    sayHello: "FOO" | "xstate.stop";
   };
   eventsCausingServices: {};
   eventsCausingGuards: {};
@@ -490,8 +490,8 @@ exports[`getTypegenOutput exit-action-parallel-root-event-only-within-final-conf
 export interface Typegen0 {
   "@@xstate/typegen": true;
   internalEvents: {
-    "xstate.stop": { type: "xstate.stop" };
     "xstate.init": { type: "xstate.init" };
+    "xstate.stop": { type: "xstate.stop" };
   };
   invokeSrcNameMap: {};
   missingImplementations: {
@@ -510,15 +510,15 @@ export interface Typegen0 {
     delays: never;
   };
   eventsCausingActions: {
-    rootExit: "xstate.stop" | "TICK_A2" | "TICK_B2";
-    aExit: "xstate.stop" | "TICK_A2" | "TICK_B2";
-    a1Exit: "xstate.stop" | "TICK_A1";
-    a2Exit: "xstate.stop" | "TICK_A2";
-    a3Exit: "xstate.stop" | "TICK_A2" | "TICK_B2";
-    bExit: "xstate.stop" | "TICK_B2" | "TICK_A2";
-    b1Exit: "xstate.stop" | "TICK_B1";
-    b2Exit: "xstate.stop" | "TICK_B2";
-    b3Exit: "xstate.stop" | "TICK_B2" | "TICK_A2";
+    a1Exit: "TICK_A1" | "xstate.stop";
+    a2Exit: "TICK_A2" | "xstate.stop";
+    a3Exit: "TICK_A2" | "TICK_B2" | "xstate.stop";
+    aExit: "TICK_A2" | "TICK_B2" | "xstate.stop";
+    b1Exit: "TICK_B1" | "xstate.stop";
+    b2Exit: "TICK_B2" | "xstate.stop";
+    b3Exit: "TICK_A2" | "TICK_B2" | "xstate.stop";
+    bExit: "TICK_A2" | "TICK_B2" | "xstate.stop";
+    rootExit: "TICK_A2" | "TICK_B2" | "xstate.stop";
   };
   eventsCausingServices: {};
   eventsCausingGuards: {};
@@ -544,8 +544,8 @@ exports[`getTypegenOutput exit-action-parallel-root-with-final-states 1`] = `
 export interface Typegen0 {
   "@@xstate/typegen": true;
   internalEvents: {
-    "xstate.stop": { type: "xstate.stop" };
     "xstate.init": { type: "xstate.init" };
+    "xstate.stop": { type: "xstate.stop" };
   };
   invokeSrcNameMap: {};
   missingImplementations: {
@@ -555,9 +555,9 @@ export interface Typegen0 {
     delays: never;
   };
   eventsCausingActions: {
-    rootExit: "xstate.stop" | "TICK_A" | "TICK_B";
-    aExit: "xstate.stop" | "TICK_A" | "TICK_B";
-    bExit: "xstate.stop" | "TICK_B" | "TICK_A";
+    aExit: "TICK_A" | "TICK_B" | "xstate.stop";
+    bExit: "TICK_A" | "TICK_B" | "xstate.stop";
+    rootExit: "TICK_A" | "TICK_B" | "xstate.stop";
   };
   eventsCausingServices: {};
   eventsCausingGuards: {};
@@ -581,8 +581,8 @@ exports[`getTypegenOutput exit-action-parallel-root-with-missing-final-state 1`]
 export interface Typegen0 {
   "@@xstate/typegen": true;
   internalEvents: {
-    "xstate.stop": { type: "xstate.stop" };
     "xstate.init": { type: "xstate.init" };
+    "xstate.stop": { type: "xstate.stop" };
   };
   invokeSrcNameMap: {};
   missingImplementations: {
@@ -592,9 +592,9 @@ export interface Typegen0 {
     delays: never;
   };
   eventsCausingActions: {
-    rootExit: "xstate.stop";
     aExit: "xstate.stop";
     bExit: "xstate.stop";
+    rootExit: "xstate.stop";
   };
   eventsCausingServices: {};
   eventsCausingGuards: {};
@@ -618,8 +618,8 @@ exports[`getTypegenOutput exit-action-parallel-root-with-mixed-states 1`] = `
 export interface Typegen0 {
   "@@xstate/typegen": true;
   internalEvents: {
-    "xstate.stop": { type: "xstate.stop" };
     "xstate.init": { type: "xstate.init" };
+    "xstate.stop": { type: "xstate.stop" };
   };
   invokeSrcNameMap: {};
   missingImplementations: {
@@ -637,62 +637,62 @@ export interface Typegen0 {
     delays: never;
   };
   eventsCausingActions: {
-    rootExit:
-      | "xstate.stop"
-      | "TICK_A11"
-      | "TICK_A21"
-      | "TICK_B11"
-      | "TICK_B21"
-      | "TICK_C1";
-    aExit:
-      | "xstate.stop"
-      | "TICK_A11"
-      | "TICK_A21"
-      | "TICK_B11"
-      | "TICK_B21"
-      | "TICK_C1";
     a12Exit:
-      | "xstate.stop"
       | "TICK_A11"
       | "TICK_A21"
       | "TICK_B11"
       | "TICK_B21"
-      | "TICK_C1";
-    a22Exit:
-      | "xstate.stop"
-      | "TICK_A21"
-      | "TICK_A11"
-      | "TICK_B11"
-      | "TICK_B21"
-      | "TICK_C1";
-    bExit:
-      | "xstate.stop"
-      | "TICK_A11"
-      | "TICK_A21"
-      | "TICK_B11"
-      | "TICK_B21"
-      | "TICK_C1";
-    b12Exit:
-      | "xstate.stop"
-      | "TICK_B11"
-      | "TICK_A11"
-      | "TICK_A21"
-      | "TICK_B21"
-      | "TICK_C1";
-    b22Exit:
-      | "xstate.stop"
-      | "TICK_B21"
-      | "TICK_A11"
-      | "TICK_A21"
-      | "TICK_B11"
-      | "TICK_C1";
-    cExit:
-      | "xstate.stop"
       | "TICK_C1"
+      | "xstate.stop";
+    a22Exit:
       | "TICK_A11"
       | "TICK_A21"
       | "TICK_B11"
-      | "TICK_B21";
+      | "TICK_B21"
+      | "TICK_C1"
+      | "xstate.stop";
+    aExit:
+      | "TICK_A11"
+      | "TICK_A21"
+      | "TICK_B11"
+      | "TICK_B21"
+      | "TICK_C1"
+      | "xstate.stop";
+    b12Exit:
+      | "TICK_A11"
+      | "TICK_A21"
+      | "TICK_B11"
+      | "TICK_B21"
+      | "TICK_C1"
+      | "xstate.stop";
+    b22Exit:
+      | "TICK_A11"
+      | "TICK_A21"
+      | "TICK_B11"
+      | "TICK_B21"
+      | "TICK_C1"
+      | "xstate.stop";
+    bExit:
+      | "TICK_A11"
+      | "TICK_A21"
+      | "TICK_B11"
+      | "TICK_B21"
+      | "TICK_C1"
+      | "xstate.stop";
+    cExit:
+      | "TICK_A11"
+      | "TICK_A21"
+      | "TICK_B11"
+      | "TICK_B21"
+      | "TICK_C1"
+      | "xstate.stop";
+    rootExit:
+      | "TICK_A11"
+      | "TICK_A21"
+      | "TICK_B11"
+      | "TICK_B21"
+      | "TICK_C1"
+      | "xstate.stop";
   };
   eventsCausingServices: {};
   eventsCausingGuards: {};
@@ -731,8 +731,8 @@ exports[`getTypegenOutput exit-action-parallel-root-with-parallel-states 1`] = `
 export interface Typegen0 {
   "@@xstate/typegen": true;
   internalEvents: {
-    "xstate.stop": { type: "xstate.stop" };
     "xstate.init": { type: "xstate.init" };
+    "xstate.stop": { type: "xstate.stop" };
   };
   invokeSrcNameMap: {};
   missingImplementations: {
@@ -753,17 +753,17 @@ export interface Typegen0 {
     delays: never;
   };
   eventsCausingActions: {
-    rootExit: "xstate.stop" | "TICK_A11" | "TICK_A21" | "TICK_B11" | "TICK_B21";
-    aExit: "xstate.stop" | "TICK_A11" | "TICK_A21" | "TICK_B11" | "TICK_B21";
-    a1Exit: "xstate.stop" | "TICK_A11" | "TICK_A21" | "TICK_B11" | "TICK_B21";
-    a12Exit: "xstate.stop" | "TICK_A11" | "TICK_A21" | "TICK_B11" | "TICK_B21";
-    a2Exit: "xstate.stop" | "TICK_A21" | "TICK_A11" | "TICK_B11" | "TICK_B21";
-    a22Exit: "xstate.stop" | "TICK_A21" | "TICK_A11" | "TICK_B11" | "TICK_B21";
-    bExit: "xstate.stop" | "TICK_A11" | "TICK_A21" | "TICK_B11" | "TICK_B21";
-    b1Exit: "xstate.stop" | "TICK_B11" | "TICK_A11" | "TICK_A21" | "TICK_B21";
-    b12Exit: "xstate.stop" | "TICK_B11" | "TICK_A11" | "TICK_A21" | "TICK_B21";
-    b2Exit: "xstate.stop" | "TICK_B21" | "TICK_A11" | "TICK_A21" | "TICK_B11";
-    b22Exit: "xstate.stop" | "TICK_B21" | "TICK_A11" | "TICK_A21" | "TICK_B11";
+    a12Exit: "TICK_A11" | "TICK_A21" | "TICK_B11" | "TICK_B21" | "xstate.stop";
+    a1Exit: "TICK_A11" | "TICK_A21" | "TICK_B11" | "TICK_B21" | "xstate.stop";
+    a22Exit: "TICK_A11" | "TICK_A21" | "TICK_B11" | "TICK_B21" | "xstate.stop";
+    a2Exit: "TICK_A11" | "TICK_A21" | "TICK_B11" | "TICK_B21" | "xstate.stop";
+    aExit: "TICK_A11" | "TICK_A21" | "TICK_B11" | "TICK_B21" | "xstate.stop";
+    b12Exit: "TICK_A11" | "TICK_A21" | "TICK_B11" | "TICK_B21" | "xstate.stop";
+    b1Exit: "TICK_A11" | "TICK_A21" | "TICK_B11" | "TICK_B21" | "xstate.stop";
+    b22Exit: "TICK_A11" | "TICK_A21" | "TICK_B11" | "TICK_B21" | "xstate.stop";
+    b2Exit: "TICK_A11" | "TICK_A21" | "TICK_B11" | "TICK_B21" | "xstate.stop";
+    bExit: "TICK_A11" | "TICK_A21" | "TICK_B11" | "TICK_B21" | "xstate.stop";
+    rootExit: "TICK_A11" | "TICK_A21" | "TICK_B11" | "TICK_B21" | "xstate.stop";
   };
   eventsCausingServices: {};
   eventsCausingGuards: {};
@@ -798,8 +798,8 @@ exports[`getTypegenOutput exit-action-root-external-transition 1`] = `
 export interface Typegen0 {
   "@@xstate/typegen": true;
   internalEvents: {
-    "xstate.stop": { type: "xstate.stop" };
     "xstate.init": { type: "xstate.init" };
+    "xstate.stop": { type: "xstate.stop" };
   };
   invokeSrcNameMap: {};
   missingImplementations: {
@@ -809,7 +809,7 @@ export interface Typegen0 {
     delays: never;
   };
   eventsCausingActions: {
-    rootExit: "xstate.stop" | "FOO";
+    rootExit: "FOO" | "xstate.stop";
   };
   eventsCausingServices: {};
   eventsCausingGuards: {};
@@ -826,8 +826,8 @@ exports[`getTypegenOutput exit-action-root-final-state 1`] = `
 export interface Typegen0 {
   "@@xstate/typegen": true;
   internalEvents: {
-    "xstate.stop": { type: "xstate.stop" };
     "xstate.init": { type: "xstate.init" };
+    "xstate.stop": { type: "xstate.stop" };
   };
   invokeSrcNameMap: {};
   missingImplementations: {
@@ -837,8 +837,8 @@ export interface Typegen0 {
     delays: never;
   };
   eventsCausingActions: {
-    rootExit: "xstate.stop" | "TICK";
-    finalExit: "xstate.stop" | "TICK";
+    finalExit: "TICK" | "xstate.stop";
+    rootExit: "TICK" | "xstate.stop";
   };
   eventsCausingServices: {};
   eventsCausingGuards: {};
@@ -855,8 +855,8 @@ exports[`getTypegenOutput exit-action-root-multiple-final-states 1`] = `
 export interface Typegen0 {
   "@@xstate/typegen": true;
   internalEvents: {
-    "xstate.stop": { type: "xstate.stop" };
     "xstate.init": { type: "xstate.init" };
+    "xstate.stop": { type: "xstate.stop" };
   };
   invokeSrcNameMap: {};
   missingImplementations: {
@@ -866,10 +866,10 @@ export interface Typegen0 {
     delays: never;
   };
   eventsCausingActions: {
-    rootExit: "xstate.stop" | "TICK_B" | "TICK_C";
-    bExit: "xstate.stop" | "TICK_B";
-    cExit: "xstate.stop" | "TICK_C";
+    bExit: "TICK_B" | "xstate.stop";
+    cExit: "TICK_C" | "xstate.stop";
     dExit: "xstate.stop";
+    rootExit: "TICK_B" | "TICK_C" | "xstate.stop";
   };
   eventsCausingServices: {};
   eventsCausingGuards: {};
@@ -886,8 +886,8 @@ exports[`getTypegenOutput exit-action-within-ancestor-with-external-transition-o
 export interface Typegen0 {
   "@@xstate/typegen": true;
   internalEvents: {
-    "xstate.stop": { type: "xstate.stop" };
     "xstate.init": { type: "xstate.init" };
+    "xstate.stop": { type: "xstate.stop" };
   };
   invokeSrcNameMap: {};
   missingImplementations: {
@@ -914,8 +914,8 @@ exports[`getTypegenOutput exit-action-within-ancestor-with-internal-transition 1
 export interface Typegen0 {
   "@@xstate/typegen": true;
   internalEvents: {
-    "xstate.stop": { type: "xstate.stop" };
     "xstate.init": { type: "xstate.init" };
+    "xstate.stop": { type: "xstate.stop" };
   };
   invokeSrcNameMap: {};
   missingImplementations: {

--- a/packages/shared/src/getStateMatchesObjectSyntax.ts
+++ b/packages/shared/src/getStateMatchesObjectSyntax.ts
@@ -9,7 +9,22 @@ export const getStateMatchesObjectSyntax = (
     const states: string[] =
       depth === 0
         ? []
-        : Object.keys(subState.states).map((state) => JSON.stringify(state));
+        : Object.keys(subState.states)
+            .sort()
+            .map((state) =>
+              JSON.stringify(state, (_key, value) => {
+                if (typeof value !== "object") {
+                  return value;
+                }
+                return Object.keys(value).reduce<Record<string, any>>(
+                  (acc, key) => {
+                    acc[key] = value[key];
+                    return acc;
+                  },
+                  {}
+                );
+              })
+            );
 
     const substatesWithChildren = Object.entries(subState.states).filter(
       ([, value]) => {
@@ -20,6 +35,7 @@ export const getStateMatchesObjectSyntax = (
     if (substatesWithChildren.length > 0) {
       states.push(
         `{ ${substatesWithChildren
+          .sort(([stateA], [stateB]) => (stateA < stateB ? -1 : 1))
           .map(([state, value]) => {
             return `${JSON.stringify(state)}?: ${getUnionForSubState(
               value,

--- a/packages/shared/src/getTypegenOutput.ts
+++ b/packages/shared/src/getTypegenOutput.ts
@@ -63,6 +63,7 @@ export const getTypegenOutput = (event: {
 
         const requiredActions = actions
           .filter((action) => !machine.actionsInOptions.includes(action.name))
+          .sort()
           .map((action) => JSON.stringify(action.name))
           .join(" | ");
 
@@ -70,24 +71,30 @@ export const getTypegenOutput = (event: {
           .filter(
             (service) => !machine.servicesInOptions.includes(service.name)
           )
+          .sort()
           .map((service) => JSON.stringify(service.name))
           .join(" | ");
 
         const requiredGuards = guards
           .filter((guard) => !machine.guardsInOptions.includes(guard.name))
+          .sort()
           .map((guard) => JSON.stringify(guard.name))
           .join(" | ");
 
         const requiredDelays = delays
           .filter((delay) => !machine.delaysInOptions.includes(delay.name))
+          .sort()
           .map((delay) => JSON.stringify(delay.name))
           .join(" | ");
 
-        const tags = machine.tags.map((tag) => JSON.stringify(tag)).join(" | ");
+        const tags = machine.tags
+          .sort()
+          .map((tag) => JSON.stringify(tag))
+          .join(" | ");
 
-        const matchesStates = introspectResult.stateMatches.map((candidate) =>
-          JSON.stringify(candidate)
-        );
+        const matchesStates = introspectResult.stateMatches
+          .sort()
+          .map((candidate) => JSON.stringify(candidate));
 
         const objectSyntax = getStateMatchesObjectSyntax(introspectResult);
 
@@ -124,7 +131,10 @@ export const getTypegenOutput = (event: {
         return `export interface Typegen${index} {
           '@@xstate/typegen': true;
           internalEvents: {
-            ${Object.values(internalEvents).join("\n")}
+            ${Object.entries(internalEvents)
+              .sort(([keyA], [keyB]) => (keyA < keyB ? -1 : 1))
+              .map(([, value]) => value)
+              .join("\n")}
           };
           invokeSrcNameMap: {
             ${Array.from(introspectResult.serviceSrcToIdMap)
@@ -133,6 +143,7 @@ export const getTypegenOutput = (event: {
                   (service) => service.src === src
                 );
               })
+              .sort(([srcA], [srcB]) => (srcA < srcB ? -1 : 1))
               .map(([src, ids]) => {
                 return `${JSON.stringify(src)}: ${Array.from(ids)
                   .map((item) => JSON.stringify(`done.invoke.${item}`))
@@ -201,6 +212,7 @@ const collectInternalEvents = (lineArrays: { events: string[] }[][]) => {
 
 const displayEventsCausing = (lines: { name: string; events: string[] }[]) => {
   return lines
+    .sort((lineA, lineB) => (lineA.name < lineB.name ? -1 : 1))
     .map((line) => {
       return `${JSON.stringify(line.name)}: ${
         line.events.length
@@ -210,6 +222,7 @@ const displayEventsCausing = (lines: { name: string; events: string[] }[]) => {
               })
             )
               .map((event) => JSON.stringify(event))
+              .sort()
               .join(" | ")
           : "never"
       };`;


### PR DESCRIPTION
This doesn't come with any change in the functionality but it makes our snapshots more resilient to the internal implementation.