### PR TITLE
Updated xsm snippet for TypeScript machines

### DIFF
--- a/.changeset/flat-socks-tie.md
+++ b/.changeset/flat-socks-tie.md
@@ -1,0 +1,5 @@
+---
+"stately-vscode": patch
+---
+
+Updated `xsm` snippet for TypeScript machines to make it easier to type context and events.

--- a/apps/extension/client/snippets/xstate.code-snippets
+++ b/apps/extension/client/snippets/xstate.code-snippets
@@ -13,7 +13,7 @@
     "prefix": "xsm",
     "body": [
       "import { createMachine } from 'xstate';",
-      "const ${1:nameOf}Machine = createMachine({\n\tid: '${1:nameOf}',\n\ttsTypes: {},\n\tschema: {\n\t\tcontext: {} as { value: string },\n\t\tevents: {} as { type: 'FOO' },\n\t},\n\tcontext: {\n\t\tvalue: '',\n\t},\n\tinitial: '${2:initialState}',\n\tstates: {\n\t\t${2:initialState}: {$0},\n\t},\n});"
+      "const ${1:nameOf}Machine = createMachine({\n\tid: '${1:nameOf}',\n\ttsTypes: {},\n\tschema: {\n\t\tcontext: {} as { ${2:contextType} },\n\t\tevents: {} as { type: '${3:eventType}' },\n\t},\n\tcontext: {\n\t\t${4:initialContextValue},\n\t},\n\tinitial: '${5:initialState}',\n\tstates: {\n\t\t${5:initialState}: {},\n\t},\n});$0"
     ],
     "description": "Outline for XState Typegen Machine"
   }


### PR DESCRIPTION
Based on user feedback this PR updates the `xsm` snippet for typed machines. It makes it easier to do the initial type definition for context and events.

See the updated snippet in action here: https://twitter.com/andersmellson/status/1557650375150297089