### PR TITLE
add pull_request for ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,16 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request && github.event.pull_request.head.sha || env.GITHUB_SHA }}
       - uses: actions/setup-node@v2
         with:
           node-version: 14.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: CI
-on:
-  push:
-    branches:
-      - "**"
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
I noticed that the workflow for #202 ran on my fork but the result wasn't reported in the pull request itself, which makes it difficult for yall to check ci success/failure for outside contributor PRs. I believe this should resolve that and run the workflow on any push or pull request.