### PR TITLE
run turbo codemods

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,5 +97,6 @@
     "turbo": "^1.1.2",
     "typescript": "^4.3.5"
   },
-  "prettier": {}
+  "prettier": {},
+  "packageManager": "yarn@1.22.19"
 }

--- a/package.json
+++ b/package.json
@@ -42,41 +42,6 @@
       "packages/*"
     ]
   },
-  "turbo": {
-    "globalDependencies": [
-      "package.json"
-    ],
-    "pipeline": {
-      "lint": {
-        "outputs": []
-      },
-      "test": {
-        "outputs": []
-      },
-      "viz:build": {
-        "outputs": [
-          "scripts/vizWebview.js"
-        ],
-        "cache": false
-      },
-      "editor:build": {
-        "outputs": [
-          "scripts/editorWebview.js"
-        ],
-        "cache": false
-      },
-      "build": {
-        "dependsOn": [
-          "viz:build",
-          "editor:build"
-        ],
-        "outputs": [
-          "dist/**"
-        ],
-        "cache": false
-      }
-    }
-  },
   "dependencies": {
     "@babel/core": "^7.12.10",
     "@babel/plugin-transform-modules-commonjs": "^7.16.8",

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,35 @@
+{
+  "globalDependencies": [
+    "package.json"
+  ],
+  "pipeline": {
+    "lint": {
+      "outputs": []
+    },
+    "test": {
+      "outputs": []
+    },
+    "viz:build": {
+      "outputs": [
+        "scripts/vizWebview.js"
+      ],
+      "cache": false
+    },
+    "editor:build": {
+      "outputs": [
+        "scripts/editorWebview.js"
+      ],
+      "cache": false
+    },
+    "build": {
+      "dependsOn": [
+        "viz:build",
+        "editor:build"
+      ],
+      "outputs": [
+        "dist/**"
+      ],
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
This PR resolves a few warnings reported by `turbo` in the ci pipeline:

```
Warning:  Turbo configuration now lives in "turbo.json". Migrate to turbo.json by running "npx @turbo/codemod create-turbo-config"
Warning:  Did not find "packageManager" in your package.json. Please run "npx @turbo/codemod add-package-manager"
```

Accomplished this by running the provided codemods