### PR TITLE
generate types for actions caused by pure calls

### DIFF
--- a/packages/machine-extractor/src/__tests__/pure.test.ts
+++ b/packages/machine-extractor/src/__tests__/pure.test.ts
@@ -1,0 +1,47 @@
+import { groupByUniqueName } from "../groupByUniqueName";
+import { parseMachinesFromFile } from "../parseMachinesFromFile";
+
+describe("pure parsing", () => {
+  it("should be able to grab actions declared inside a pure action", () => {
+    const result = parseMachinesFromFile(`
+			createMachine({
+				entry: [
+					pure((context, event) => ["1"])
+				],
+        on: {
+          event: {
+            actions: pure((context, event) => ["2"])
+          }
+        }
+			})
+		`);
+
+    const named = Object.keys(
+      groupByUniqueName(result.machines[0].getAllActions(["named"]))
+    );
+
+    expect(named).toHaveLength(2);
+    expect(named).toEqual(["1", "2"]);
+  });
+});
+
+describe("pure in machine options", () => {
+  it("should be able to grab actions declared in a pure in machine options", () => {
+    const result = parseMachinesFromFile(`
+			createMachine({
+				entry: 'doStuff',
+			}, {
+				actions: {
+					doStuff: pure((context, event) => ["1", "2"])
+				}
+			})
+		`);
+
+    const named = Object.keys(
+      groupByUniqueName(result.machines[0].getAllActions(["named"]))
+    );
+
+    expect(named).toHaveLength(3);
+    expect(named).toEqual(["1", "2", "doStuff"]);
+  });
+});

--- a/packages/machine-extractor/src/namedActions.ts
+++ b/packages/machine-extractor/src/namedActions.ts
@@ -4,7 +4,6 @@ import {
   done,
   escalate,
   log,
-  pure,
   raise,
   respond,
   sendParent,
@@ -87,20 +86,7 @@ export const LogAction = wrapParserResult(
       declarationType: "inline",
       inlineDeclarationId: context.getNodeHash(node),
     };
-  },
-);
-
-export const PureAction = wrapParserResult(
-  namedFunctionCall("pure", AnyNode),
-  (result, node, context): ActionNode => {
-    return {
-      node: result.node,
-      action: pure(() => []),
-      name: "",
-      declarationType: "inline",
-      inlineDeclarationId: context.getNodeHash(node),
-    };
-  },
+  }
 );
 
 export const RaiseAction = wrapParserResult(

--- a/packages/machine-extractor/src/options.ts
+++ b/packages/machine-extractor/src/options.ts
@@ -1,4 +1,4 @@
-import { ActionNode, ChooseAction } from "./actions";
+import { ActionNode, ChooseAction, PureAction } from "./actions";
 import { maybeIdentifierTo } from "./identifiers";
 import { AnyNode, BooleanLiteral } from "./scalars";
 import { maybeTsAsExpression } from "./tsAsExpression";
@@ -8,7 +8,11 @@ import { types as t } from "@babel/core";
 
 const MachineOptionsObject = objectTypeWithKnownKeys({
   actions: objectOf(
-    unionType<ActionNode | { node: t.Node }>([ChooseAction, AnyNode])
+    unionType<ActionNode | { node: t.Node }>([
+      ChooseAction,
+      PureAction,
+      AnyNode,
+    ])
   ),
   services: objectOf(AnyNode),
   guards: objectOf(AnyNode),

--- a/packages/shared/src/__tests__/__examples__/pure-defined-in-config.ts
+++ b/packages/shared/src/__tests__/__examples__/pure-defined-in-config.ts
@@ -1,0 +1,12 @@
+import { createMachine } from "xstate";
+import { pure } from "xstate/lib/actions";
+
+export const machine = createMachine({
+  tsTypes: {} as import("./pure-defined-in-config.typegen").Typegen0,
+  entry: pure(() => ["someAction", "someOtherAction"]),
+  on: {
+    event: {
+      actions: pure(() => ["someAction", "someOtherAction"]),
+    },
+  },
+});

--- a/packages/shared/src/__tests__/__examples__/pure-defined-in-implementations.ts
+++ b/packages/shared/src/__tests__/__examples__/pure-defined-in-implementations.ts
@@ -1,0 +1,19 @@
+import { createMachine } from "xstate";
+import { pure } from "xstate/lib/actions";
+
+export const machine = createMachine(
+  {
+    tsTypes: {} as import("./pure-defined-in-implementations.typegen").Typegen0,
+    entry: "pure",
+    on: {
+      event: {
+        actions: "pure",
+      },
+    },
+  },
+  {
+    actions: {
+      pure: pure((context, event) => ["someAction", "someOtherAction"]),
+    },
+  }
+);

--- a/packages/shared/src/__tests__/__snapshots__/getTypegenOutput.test.ts.snap
+++ b/packages/shared/src/__tests__/__snapshots__/getTypegenOutput.test.ts.snap
@@ -1050,6 +1050,63 @@ export interface Typegen0 {
 "
 `;
 
+exports[`getTypegenOutput pure-defined-in-config 1`] = `
+"// This file was automatically generated. Edits will be overwritten
+
+export interface Typegen0 {
+  "@@xstate/typegen": true;
+  internalEvents: {
+    "xstate.init": { type: "xstate.init" };
+  };
+  invokeSrcNameMap: {};
+  missingImplementations: {
+    actions: "someAction" | "someOtherAction";
+    services: never;
+    guards: never;
+    delays: never;
+  };
+  eventsCausingActions: {
+    someAction: "event" | "xstate.init";
+    someOtherAction: "event" | "xstate.init";
+  };
+  eventsCausingServices: {};
+  eventsCausingGuards: {};
+  eventsCausingDelays: {};
+  matchesStates: undefined;
+  tags: never;
+}
+"
+`;
+
+exports[`getTypegenOutput pure-defined-in-implementations 1`] = `
+"// This file was automatically generated. Edits will be overwritten
+
+export interface Typegen0 {
+  "@@xstate/typegen": true;
+  internalEvents: {
+    "xstate.init": { type: "xstate.init" };
+  };
+  invokeSrcNameMap: {};
+  missingImplementations: {
+    actions: "someAction" | "someOtherAction";
+    services: never;
+    guards: never;
+    delays: never;
+  };
+  eventsCausingActions: {
+    pure: "event" | "xstate.init";
+    someAction: "event" | "xstate.init";
+    someOtherAction: "event" | "xstate.init";
+  };
+  eventsCausingServices: {};
+  eventsCausingGuards: {};
+  eventsCausingDelays: {};
+  matchesStates: undefined;
+  tags: never;
+}
+"
+`;
+
 exports[`getTypegenOutput service-provided-function 1`] = `
 "// This file was automatically generated. Edits will be overwritten
 

--- a/packages/shared/src/getDocumentValidationsResults.ts
+++ b/packages/shared/src/getDocumentValidationsResults.ts
@@ -18,9 +18,11 @@ export const getDocumentValidationsResults = (
       const config = parseResult.toConfig();
       const chooseActionsForOptions =
         parseResult.getChooseActionsToAddToOptions();
+      const pureActionsForOptions = parseResult.getPureActionsToAddToOptions();
+
       try {
         const machine: any = createMachine(config as any, {
-          actions: chooseActionsForOptions,
+          actions: { ...chooseActionsForOptions, ...pureActionsForOptions },
         });
         const introspectionResult = introspectMachine(machine as any);
         return {

--- a/packages/shared/src/getTypegenOutput.ts
+++ b/packages/shared/src/getTypegenOutput.ts
@@ -17,6 +17,7 @@ export const getTypegenOutput = (event: {
     | "tags"
     | "allServices"
     | "chooseActionsInOptions"
+    | "pureActionsInOptions"
   >[];
 }) => {
   return `
@@ -39,6 +40,7 @@ export const getTypegenOutput = (event: {
           guards: guardsToMock,
           actions: {
             ...machine.chooseActionsInOptions,
+            ...machine.pureActionsInOptions,
           },
         });
 

--- a/packages/shared/src/introspectMachine.ts
+++ b/packages/shared/src/introspectMachine.ts
@@ -219,6 +219,18 @@ function collectAction(
         ctx.actions.addEventToItem(condActions, eventType);
       }
     });
+  } else if (actionObject.type === "xstate.pure") {
+    try {
+      const pureActions = actionObject.get();
+
+      if (Array.isArray(pureActions)) {
+        pureActions.forEach((pureAction) => {
+          ctx.actions.addEventToItem(pureAction.type, eventType);
+        });
+      }
+    } catch (e) {
+      return;
+    }
   } else {
     ctx.actions.addEventToItem(actionObject.type, eventType);
   }

--- a/packages/shared/src/makeXStateUpdateEvent.ts
+++ b/packages/shared/src/makeXStateUpdateEvent.ts
@@ -56,6 +56,8 @@ export const makeXStateUpdateEvent = (
         ),
         chooseActionsInOptions:
           machine.parseResult?.getChooseActionsToAddToOptions() || {},
+        pureActionsInOptions:
+          machine.parseResult?.getPureActionsToAddToOptions() || {},
       };
     }),
   };

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -33,6 +33,7 @@ export interface XStateUpdateMachine {
   tags: string[];
   hasTypesNode: boolean;
   chooseActionsInOptions: MachineOptions<any, any, any>["actions"];
+  pureActionsInOptions: MachineOptions<any, any, any>["actions"];
 }
 
 export interface XStateUpdateEvent {


### PR DESCRIPTION
This draft PR adds `missingImplementations` and `eventsCausingActions` typegen for `pure` calls that return an array including action `type` strings.

This is a very naive implementation because a function body and return can be shaped in many different ways, so covering that would require a significant amount more effort. This covers the simple case of `pure(() => ["action", "types", "as", "strings", assign({ butActionFunctionsAreIgnored: () => true })]`.

The reason for this PR is that actions in the array returned from `pure` are unable to inherit the generic types provided to `pure` through typegen. For example:

https://codesandbox.io/s/great-brook-mb7c4i?file=/src/index.tsx:1072-1129

The problems get even worse if `strict` (specifically `strictFunctionTypes`) is enabled in `tsconfig.json`.

To get around this limitation, what I'd like to do instead is to create separate actions for each of the actions I'd like to trigger, and then "bundle" them together in a single `pure` action that I can refer to. Something like this:

```ts
createMachine(
  {
    entry: 'doTheThing',
  },
  {
    actions: {
      assignAThing: assign({something: true}),
      sendAThing: send(
        {type: 'whatever'},
        {to: (context) => context.someActorRef},
      ),
      doTheThing: pure(() => ['assignAThing', 'sendAThing']),
    },
  },
)
```

This allows me to achieve the same outcome as calling the actions within `pure` while retaining type safety, but as it stands, there are two problems with this: 
- typegen doesn't detect actions returned from `pure` so it complains that `assignAThing`/`sendAThing` are unused and `eventsCausingActions` doesn't connect the actions with the event
- `xstate` types don't allow actions as strings even though it actually works fine (PR for that incoming in the `xstate` repo :wink:)

Without this change, I'm stuck referring to each action separately:

```ts
createMachine({
  entry: ['assignAThing', 'sendAThing']
})
```

That's not so bad until you end up in a situation where you want to bundle the same actions together in different places, and have to maintain separate arrays all over the place.