### PR TITLE
expose path and node in traversal

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true,
     "source.organizeImports": true
-  }
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/packages/machine-extractor/src/actions.ts
+++ b/packages/machine-extractor/src/actions.ts
@@ -50,7 +50,7 @@ export interface ParsedChooseCondition {
 export const ActionAsIdentifier = maybeTsAsExpression(
   createParser({
     babelMatcher: t.isIdentifier,
-    parseNode: (path, context): ActionNode => {
+    extract: (path, context): ActionNode => {
       return {
         action: path.node.name,
         node: path.node,
@@ -67,7 +67,7 @@ export const ActionAsFunctionExpression = maybeTsAsExpression(
   maybeIdentifierTo(
     createParser({
       babelMatcher: isFunctionOrArrowFunctionExpression,
-      parseNode: (path, context): ActionNode => {
+      extract: (path, context): ActionNode => {
         const action = function actions() {};
         const id = context.getNodeHash(path.node);
 
@@ -89,7 +89,7 @@ export const ActionAsString = maybeTsAsExpression(
   maybeIdentifierTo(
     createParser({
       babelMatcher: t.isStringLiteral,
-      parseNode: (path, context): ActionNode => {
+      extract: (path, context): ActionNode => {
         return {
           path,
           action: path.node.value,
@@ -105,7 +105,7 @@ export const ActionAsString = maybeTsAsExpression(
 
 export const ActionAsNode = createParser({
   babelMatcher: t.isNode,
-  parseNode: (path, context): ActionNode => {
+  extract: (path, context): ActionNode => {
     const id = context.getNodeHash(path.node);
     return {
       path,
@@ -177,7 +177,7 @@ interface AssignFirstArg {
 
 const AssignFirstArgObject = createParser({
   babelMatcher: t.isObjectExpression,
-  parseNode: (path, context) => {
+  extract: (path, context) => {
     return {
       path,
       node: path.node,
@@ -188,7 +188,7 @@ const AssignFirstArgObject = createParser({
 
 const AssignFirstArgFunction = createParser({
   babelMatcher: isFunctionOrArrowFunctionExpression,
-  parseNode: (path, context) => {
+  extract: (path, context) => {
     const value = function anonymous() {
       return {};
     };

--- a/packages/machine-extractor/src/actions.ts
+++ b/packages/machine-extractor/src/actions.ts
@@ -1,4 +1,4 @@
-import { types as t } from "@babel/core";
+import { NodePath, types as t } from "@babel/core";
 import { Action, ChooseCondition } from "xstate";
 import { assign, choose, forwardTo, send } from "xstate/lib/actions";
 import { Cond, CondNode } from "./conds";
@@ -33,6 +33,7 @@ import { wrapParserResult } from "./wrapParserResult";
 
 export interface ActionNode {
   node: t.Node;
+  path: NodePath<t.Node>;
   action: Action<any, any>;
   name: string;
   chooseConditions?: ParsedChooseCondition[];
@@ -49,63 +50,67 @@ export interface ParsedChooseCondition {
 export const ActionAsIdentifier = maybeTsAsExpression(
   createParser({
     babelMatcher: t.isIdentifier,
-    parseNode: (node, context): ActionNode => {
+    parseNode: (path, context): ActionNode => {
       return {
-        action: node.name,
-        node,
-        name: node.name,
+        action: path.node.name,
+        node: path.node,
+        path,
+        name: path.node.name,
         declarationType: "identifier",
-        inlineDeclarationId: context.getNodeHash(node),
+        inlineDeclarationId: context.getNodeHash(path.node),
       };
     },
-  }),
+  })
 );
 
 export const ActionAsFunctionExpression = maybeTsAsExpression(
   maybeIdentifierTo(
     createParser({
       babelMatcher: isFunctionOrArrowFunctionExpression,
-      parseNode: (node, context): ActionNode => {
+      parseNode: (path, context): ActionNode => {
         const action = function actions() {};
-        const id = context.getNodeHash(node);
+        const id = context.getNodeHash(path.node);
 
         action.toJSON = () => id;
         return {
-          node,
+          node: path.node,
+          path,
           action,
           name: "",
           declarationType: "inline",
           inlineDeclarationId: id,
         };
       },
-    }),
-  ),
+    })
+  )
 );
 
 export const ActionAsString = maybeTsAsExpression(
   maybeIdentifierTo(
     createParser({
       babelMatcher: t.isStringLiteral,
-      parseNode: (node, context): ActionNode => {
+      parseNode: (path, context): ActionNode => {
         return {
-          action: node.value,
-          node,
-          name: node.value,
+          path,
+          action: path.node.value,
+          node: path.node,
+          name: path.node.value,
           declarationType: "named",
-          inlineDeclarationId: context.getNodeHash(node),
+          inlineDeclarationId: context.getNodeHash(path.node),
         };
       },
-    }),
-  ),
+    })
+  )
 );
 
 export const ActionAsNode = createParser({
   babelMatcher: t.isNode,
-  parseNode: (node, context): ActionNode => {
-    const id = context.getNodeHash(node);
+  parseNode: (path, context): ActionNode => {
+    const id = context.getNodeHash(path.node);
     return {
+      path,
       action: id,
-      node,
+      node: path.node,
       name: "",
       declarationType: "unknown",
       inlineDeclarationId: id,
@@ -120,12 +125,12 @@ const ChooseFirstArg = arrayOf(
     // too recursive
     // TODO - fix
     actions: maybeArrayOf(ActionAsString),
-  }),
+  })
 );
 
 export const ChooseAction = wrapParserResult(
   namedFunctionCall("choose", ChooseFirstArg),
-  (result, node, context): ActionNode => {
+  (result, path, context): ActionNode => {
     const conditions: ParsedChooseCondition[] = [];
 
     result.argument1Result?.forEach((arg1Result) => {
@@ -153,26 +158,29 @@ export const ChooseAction = wrapParserResult(
     });
 
     return {
-      node: node,
+      path,
+      node: path.node,
       action: choose(conditions.map((condition) => condition.condition)),
       chooseConditions: conditions,
       name: "",
       declarationType: "inline",
-      inlineDeclarationId: context.getNodeHash(node),
+      inlineDeclarationId: context.getNodeHash(path.node),
     };
-  },
+  }
 );
 
 interface AssignFirstArg {
+  path: NodePath<t.Node>;
   node: t.Node;
   value: {} | (() => {});
 }
 
 const AssignFirstArgObject = createParser({
   babelMatcher: t.isObjectExpression,
-  parseNode: (node, context) => {
+  parseNode: (path, context) => {
     return {
-      node,
+      path,
+      node: path.node,
       value: {},
     };
   },
@@ -180,7 +188,7 @@ const AssignFirstArgObject = createParser({
 
 const AssignFirstArgFunction = createParser({
   babelMatcher: isFunctionOrArrowFunctionExpression,
-  parseNode: (node, context) => {
+  parseNode: (path, context) => {
     const value = function anonymous() {
       return {};
     };
@@ -189,7 +197,8 @@ const AssignFirstArgFunction = createParser({
     };
 
     return {
-      node,
+      path,
+      node: path.node,
       value,
     };
   },
@@ -202,7 +211,7 @@ const AssignFirstArg = unionType<AssignFirstArg>([
 
 export const AssignAction = wrapParserResult(
   namedFunctionCall("assign", AssignFirstArg),
-  (result, node, context): ActionNode => {
+  (result, path, context): ActionNode => {
     const defaultAction = function anonymous() {
       return {};
     };
@@ -211,13 +220,14 @@ export const AssignAction = wrapParserResult(
     };
 
     return {
+      path,
       node: result.node,
       action: assign(result.argument1Result?.value || defaultAction),
       name: "",
       declarationType: "inline",
-      inlineDeclarationId: context.getNodeHash(node),
+      inlineDeclarationId: context.getNodeHash(path.node),
     };
-  },
+  }
 );
 
 export const SendActionSecondArg = objectTypeWithKnownKeys({
@@ -233,10 +243,11 @@ export const SendAction = wrapParserResult(
   namedFunctionCall(
     "send",
     unionType<{ node: t.Node; value?: string }>([StringLiteral, AnyNode]),
-    SendActionSecondArg,
+    SendActionSecondArg
   ),
-  (result, node, context): ActionNode => {
+  (result, path, context): ActionNode => {
     return {
+      path,
       node: result.node,
       name: "",
       action: send(
@@ -250,12 +261,12 @@ export const SendAction = wrapParserResult(
           id: result.argument2Result?.id?.value,
           to: result.argument2Result?.to?.value,
           delay: result.argument2Result?.delay?.value,
-        },
+        }
       ),
       declarationType: "inline",
-      inlineDeclarationId: context.getNodeHash(node),
+      inlineDeclarationId: context.getNodeHash(path.node),
     };
-  },
+  }
 );
 
 export const ForwardToActionSecondArg = objectTypeWithKnownKeys({
@@ -264,17 +275,18 @@ export const ForwardToActionSecondArg = objectTypeWithKnownKeys({
 
 export const ForwardToAction = wrapParserResult(
   namedFunctionCall("forwardTo", StringLiteral, ForwardToActionSecondArg),
-  (result, node, context): ActionNode => {
+  (result, path, context): ActionNode => {
     return {
       node: result.node,
       action: forwardTo(result.argument1Result?.value || "", {
         to: result.argument2Result?.to?.value,
       }),
+      path,
       name: "",
       declarationType: "inline",
-      inlineDeclarationId: context.getNodeHash(node),
+      inlineDeclarationId: context.getNodeHash(path.node),
     };
-  },
+  }
 );
 
 const NamedAction = unionType([
@@ -306,5 +318,5 @@ const BasicAction = unionType([
 export const ArrayOfBasicActions = maybeArrayOf(BasicAction);
 
 export const MaybeArrayOfActions = maybeArrayOf(
-  unionType([NamedAction, BasicAction]),
+  unionType([NamedAction, BasicAction])
 );

--- a/packages/machine-extractor/src/conds.ts
+++ b/packages/machine-extractor/src/conds.ts
@@ -16,7 +16,7 @@ export interface CondNode {
 
 const CondAsFunctionExpression = createParser({
   babelMatcher: isFunctionOrArrowFunctionExpression,
-  parseNode: (path, context): CondNode => {
+  extract: (path, context): CondNode => {
     return {
       path,
       node: path.node,
@@ -32,7 +32,7 @@ const CondAsFunctionExpression = createParser({
 
 const CondAsStringLiteral = createParser({
   babelMatcher: t.isStringLiteral,
-  parseNode: (path, context): CondNode => {
+  extract: (path, context): CondNode => {
     return {
       path,
       node: path.node,
@@ -46,7 +46,7 @@ const CondAsStringLiteral = createParser({
 
 const CondAsParametrizedGuard = createParser({
   babelMatcher: t.isObjectExpression,
-  parseNode: (path, context): CondNode | null => {
+  extract: (path, context): CondNode | null => {
     let propValue: t.Node | null = null;
 
     for (const prop of path.node.properties) {
@@ -80,7 +80,7 @@ const CondAsParametrizedGuard = createParser({
 
 const CondAsNode = createParser({
   babelMatcher: t.isNode,
-  parseNode: (path, context): CondNode => {
+  extract: (path, context): CondNode => {
     const id = context.getNodeHash(path.node);
     return {
       path,

--- a/packages/machine-extractor/src/createParser.ts
+++ b/packages/machine-extractor/src/createParser.ts
@@ -1,4 +1,4 @@
-import { types as t } from "@babel/core";
+import { NodePath, types as t } from "@babel/core";
 import { Parser, ParserContext } from "./types";
 
 /**
@@ -7,14 +7,14 @@ import { Parser, ParserContext } from "./types";
  */
 export const createParser = <T extends t.Node, Result>(params: {
   babelMatcher: (node: any) => node is T;
-  parseNode: (node: T, context: ParserContext) => Result;
+  parseNode: (path: NodePath<T>, context: ParserContext) => Result;
 }): Parser<T, Result> => {
-  const matches = (node: T) => {
+  const matches = (node: t.Node) => {
     return params.babelMatcher(node);
   };
-  const parse = (node: any, context: ParserContext): Result | undefined => {
-    if (!matches(node)) return undefined;
-    return params.parseNode(node, context);
+  const parse = (path: any, context: ParserContext): Result | undefined => {
+    if (!matches(path?.node)) return undefined;
+    return params.parseNode(path, context);
   };
   return {
     parse,

--- a/packages/machine-extractor/src/createParser.ts
+++ b/packages/machine-extractor/src/createParser.ts
@@ -1,20 +1,32 @@
 import { NodePath, types as t } from "@babel/core";
 import { Parser, ParserContext } from "./types";
 
+export interface CreateParserParams<T extends t.Node, Result> {
+  /**
+   * Matcher function used to determine if the current AST `Node` passed to a
+   * parser should be handled by that parser.
+   */
+  babelMatcher: (node: any) => node is T;
+  /**
+   * A function which extracts metadata about the current AST `Node` to be used
+   * later for parsing machines.
+   */
+  extract: (path: NodePath<T>, context: ParserContext) => Result;
+}
+
 /**
  * Creates a parser, which can be run later on AST nodes
  * to work out if they match
  */
-export const createParser = <T extends t.Node, Result>(params: {
-  babelMatcher: (node: any) => node is T;
-  parseNode: (path: NodePath<T>, context: ParserContext) => Result;
-}): Parser<T, Result> => {
+export const createParser = <T extends t.Node, Result>(
+  params: CreateParserParams<T, Result>
+): Parser<T, Result> => {
   const matches = (node: t.Node) => {
     return params.babelMatcher(node);
   };
   const parse = (path: any, context: ParserContext): Result | undefined => {
     if (!matches(path?.node)) return undefined;
-    return params.parseNode(path, context);
+    return params.extract(path, context);
   };
   return {
     parse,

--- a/packages/machine-extractor/src/history.ts
+++ b/packages/machine-extractor/src/history.ts
@@ -1,28 +1,31 @@
-import { types as t } from "@babel/core";
+import { NodePath, types as t } from "@babel/core";
 import { createParser } from "./createParser";
 import { unionType } from "./unionType";
 
 interface HistoryNode {
   node: t.Node;
+  path: NodePath<t.Node>;
   value: "shallow" | "deep" | boolean;
 }
 
 const HistoryAsString = createParser({
   babelMatcher: t.isStringLiteral,
-  parseNode: (node): HistoryNode => {
+  parseNode: (path): HistoryNode => {
     return {
-      node,
-      value: node.value as HistoryNode["value"],
+      node: path.node,
+      path,
+      value: path.node.value as HistoryNode["value"],
     };
   },
 });
 
 const HistoryAsBoolean = createParser({
   babelMatcher: t.isBooleanLiteral,
-  parseNode: (node): HistoryNode => {
+  parseNode: (path): HistoryNode => {
     return {
-      node,
-      value: node.value,
+      node: path.node,
+      path,
+      value: path.node.value,
     };
   },
 });

--- a/packages/machine-extractor/src/history.ts
+++ b/packages/machine-extractor/src/history.ts
@@ -10,7 +10,7 @@ interface HistoryNode {
 
 const HistoryAsString = createParser({
   babelMatcher: t.isStringLiteral,
-  parseNode: (path): HistoryNode => {
+  extract: (path): HistoryNode => {
     return {
       node: path.node,
       path,
@@ -21,7 +21,7 @@ const HistoryAsString = createParser({
 
 const HistoryAsBoolean = createParser({
   babelMatcher: t.isBooleanLiteral,
-  parseNode: (path): HistoryNode => {
+  extract: (path): HistoryNode => {
     return {
       node: path.node,
       path,

--- a/packages/machine-extractor/src/identifiers.ts
+++ b/packages/machine-extractor/src/identifiers.ts
@@ -38,7 +38,7 @@ export const identifierReferencingVariableDeclaration = <Result>(
 ) => {
   return createParser({
     babelMatcher: t.isIdentifier,
-    parseNode: (path, context) => {
+    extract: (path, context) => {
       const variableDeclarator = findVariableDeclaratorWithName(
         context.file,
         path.node.name
@@ -104,7 +104,7 @@ const deepMemberExpression: Parser<
   babelMatcher(node): node is t.MemberExpression | t.Identifier {
     return t.isIdentifier(node) || t.isMemberExpression(node);
   },
-  parseNode: (path, context) => {
+  extract: (path, context) => {
     const child = path.get("object") as unknown as NodePath<
       t.MemberExpression | t.Identifier
     >;
@@ -122,7 +122,7 @@ export const objectExpressionWithDeepPath = <Result>(
 ) =>
   createParser({
     babelMatcher: t.isObjectExpression,
-    parseNode: (path, context) => {
+    extract: (path, context) => {
       let currentIndex = 0;
       let currentPath: NodePath<t.ObjectExpression> | undefined | null = path;
 
@@ -163,7 +163,7 @@ export const memberExpressionReferencingObjectExpression = <Result>(
 ) =>
   createParser({
     babelMatcher: t.isMemberExpression,
-    parseNode: (path, context) => {
+    extract: (path, context) => {
       const result = deepMemberExpression.parse(path, context);
 
       const rootIdentifier = getRootIdentifierOfDeepMemberExpression(result);
@@ -180,7 +180,7 @@ export const memberExpressionReferencingObjectExpression = <Result>(
 
 export const memberExpressionReferencingEnumMember = createParser({
   babelMatcher: t.isMemberExpression,
-  parseNode: (path, context) => {
+  extract: (path, context) => {
     const result = deepMemberExpression.parse(path, context);
 
     const rootIdentifier = getRootIdentifierOfDeepMemberExpression(result);

--- a/packages/machine-extractor/src/invoke.ts
+++ b/packages/machine-extractor/src/invoke.ts
@@ -24,7 +24,7 @@ const InvokeSrcFunctionExpression = maybeTsAsExpression(
   maybeIdentifierTo(
     createParser({
       babelMatcher: isFunctionOrArrowFunctionExpression,
-      parseNode: (path, context): InvokeNode => {
+      extract: (path, context): InvokeNode => {
         const id = context.getNodeHash(path.node);
 
         return {
@@ -41,7 +41,7 @@ const InvokeSrcFunctionExpression = maybeTsAsExpression(
 
 const InvokeSrcNode = createParser({
   babelMatcher: t.isNode,
-  parseNode: (path, context): InvokeNode => {
+  extract: (path, context): InvokeNode => {
     const id = context.getNodeHash(path.node);
     return {
       value: id,
@@ -55,7 +55,7 @@ const InvokeSrcNode = createParser({
 
 const InvokeSrcStringLiteral = createParser({
   babelMatcher: t.isStringLiteral,
-  parseNode: (path, context): InvokeNode => ({
+  extract: (path, context): InvokeNode => ({
     value: path.node.value,
     path,
     node: path.node,
@@ -66,7 +66,7 @@ const InvokeSrcStringLiteral = createParser({
 
 const InvokeSrcIdentifier = createParser({
   babelMatcher: t.isIdentifier,
-  parseNode: (path, context): InvokeNode => {
+  extract: (path, context): InvokeNode => {
     const id = context.getNodeHash(path.node);
     return {
       value: id,

--- a/packages/machine-extractor/src/machineCallExpression.ts
+++ b/packages/machine-extractor/src/machineCallExpression.ts
@@ -17,7 +17,7 @@ export const ALLOWED_CALL_EXPRESSION_NAMES = [
 
 export const MachineCallExpression = createParser({
   babelMatcher: t.isCallExpression,
-  parseNode: (path, context) => {
+  extract: (path, context) => {
     const node = path.node;
     if (
       t.isMemberExpression(node.callee) &&

--- a/packages/machine-extractor/src/machineCallExpression.ts
+++ b/packages/machine-extractor/src/machineCallExpression.ts
@@ -1,9 +1,9 @@
 import { types as t } from "@babel/core";
-import { StateNode } from "./stateNode";
-import { GetParserResult } from "./utils";
-import { MachineOptions } from "./options";
 import { createParser } from "./createParser";
+import { MachineOptions } from "./options";
+import { StateNode } from "./stateNode";
 import { AnyTypeParameterList } from "./typeParameters";
+import { GetParserResult } from "./utils";
 
 export type TMachineCallExpression = GetParserResult<
   typeof MachineCallExpression
@@ -17,7 +17,8 @@ export const ALLOWED_CALL_EXPRESSION_NAMES = [
 
 export const MachineCallExpression = createParser({
   babelMatcher: t.isCallExpression,
-  parseNode: (node, context) => {
+  parseNode: (path, context) => {
+    const node = path.node;
     if (
       t.isMemberExpression(node.callee) &&
       t.isIdentifier(node.callee.property) &&
@@ -26,11 +27,15 @@ export const MachineCallExpression = createParser({
       return {
         callee: node.callee,
         calleeName: node.callee.property.name,
-        definition: StateNode.parse(node.arguments[0], context),
-        options: MachineOptions.parse(node.arguments[1], context),
+        definition: StateNode.parse(path.get("arguments")[0], context),
+        options: MachineOptions.parse(path.get("arguments")[1], context),
         isMemberExpression: true,
-        typeArguments: AnyTypeParameterList.parse(node.typeParameters, context),
+        typeArguments: AnyTypeParameterList.parse(
+          path.get("typeParameters"),
+          context
+        ),
         node,
+        path,
       };
     }
 
@@ -41,11 +46,15 @@ export const MachineCallExpression = createParser({
       return {
         callee: node.callee,
         calleeName: node.callee.name,
-        definition: StateNode.parse(node.arguments[0], context),
-        options: MachineOptions.parse(node.arguments[1], context),
+        definition: StateNode.parse(path.get("arguments")[0], context),
+        options: MachineOptions.parse(path.get("arguments")[1], context),
         isMemberExpression: false,
-        typeArguments: AnyTypeParameterList.parse(node.typeParameters, context),
+        typeArguments: AnyTypeParameterList.parse(
+          path.get("typeParameters"),
+          context
+        ),
         node,
+        path,
       };
     }
   },

--- a/packages/machine-extractor/src/namedActions.ts
+++ b/packages/machine-extractor/src/namedActions.ts
@@ -1,3 +1,4 @@
+import { types as t } from "@babel/core";
 import {
   after,
   cancel,
@@ -14,9 +15,8 @@ import {
 } from "xstate/lib/actions";
 import type { ActionNode } from "./actions";
 import { AnyNode, NumericLiteral, StringLiteral } from "./scalars";
-import { namedFunctionCall } from "./utils";
-import { types as t } from "@babel/core";
 import { unionType } from "./unionType";
+import { namedFunctionCall } from "./utils";
 import { wrapParserResult } from "./wrapParserResult";
 
 export const AfterAction = wrapParserResult(
@@ -25,158 +25,170 @@ export const AfterAction = wrapParserResult(
     unionType<{ node: t.Node; value: number | string }>([
       StringLiteral,
       NumericLiteral,
-    ]),
+    ])
   ),
-  (result, node, context): ActionNode => {
+  (result, path, context): ActionNode => {
     return {
+      path,
       node: result.node,
       action: after(result.argument1Result?.value || ""),
       name: "",
       declarationType: "inline",
-      inlineDeclarationId: context.getNodeHash(node),
+      inlineDeclarationId: context.getNodeHash(result.node),
     };
-  },
+  }
 );
 
 export const CancelAction = wrapParserResult(
   namedFunctionCall("cancel", AnyNode),
-  (result, node, context): ActionNode => {
+  (result, path, context): ActionNode => {
     return {
+      path,
       node: result.node,
       action: cancel(""),
       name: "",
       declarationType: "inline",
-      inlineDeclarationId: context.getNodeHash(node),
+      inlineDeclarationId: context.getNodeHash(result.node),
     };
-  },
+  }
 );
 
 export const DoneAction = wrapParserResult(
   namedFunctionCall("done", AnyNode),
-  (result, node, context): ActionNode => {
+  (result, path, context): ActionNode => {
     return {
+      path,
       node: result.node,
       action: done(""),
       name: "",
       declarationType: "inline",
-      inlineDeclarationId: context.getNodeHash(node),
+      inlineDeclarationId: context.getNodeHash(result.node),
     };
-  },
+  }
 );
 
 export const EscalateAction = wrapParserResult(
   namedFunctionCall("escalate", AnyNode),
-  (result, node, context): ActionNode => {
+  (result, path, context): ActionNode => {
     return {
+      path,
       node: result.node,
       action: escalate(""),
       name: "",
       declarationType: "inline",
-      inlineDeclarationId: context.getNodeHash(node),
+      inlineDeclarationId: context.getNodeHash(result.node),
     };
-  },
+  }
 );
 
 export const LogAction = wrapParserResult(
   namedFunctionCall("log", AnyNode),
-  (result, node, context): ActionNode => {
+  (result, path, context): ActionNode => {
     return {
+      path,
       node: result.node,
       action: log(),
       name: "",
       declarationType: "inline",
-      inlineDeclarationId: context.getNodeHash(node),
+      inlineDeclarationId: context.getNodeHash(result.node),
     };
-  },
+  }
 );
 
 export const PureAction = wrapParserResult(
   namedFunctionCall("pure", AnyNode),
-  (result, node, context): ActionNode => {
+  (result, path, context): ActionNode => {
     return {
+      path,
       node: result.node,
       action: pure(() => []),
       name: "",
       declarationType: "inline",
-      inlineDeclarationId: context.getNodeHash(node),
+      inlineDeclarationId: context.getNodeHash(result.node),
     };
-  },
+  }
 );
 
 export const RaiseAction = wrapParserResult(
   namedFunctionCall("raise", AnyNode),
-  (result, node, context): ActionNode => {
+  (result, path, context): ActionNode => {
     return {
+      path,
       node: result.node,
       action: raise(""),
       name: "",
       declarationType: "inline",
-      inlineDeclarationId: context.getNodeHash(node),
+      inlineDeclarationId: context.getNodeHash(result.node),
     };
-  },
+  }
 );
 
 export const RespondAction = wrapParserResult(
   namedFunctionCall("respond", AnyNode),
-  (result, node, context): ActionNode => {
+  (result, path, context): ActionNode => {
     return {
+      path,
       node: result.node,
       action: respond(""),
       name: "",
       declarationType: "inline",
-      inlineDeclarationId: context.getNodeHash(node),
+      inlineDeclarationId: context.getNodeHash(result.node),
     };
-  },
+  }
 );
 
 export const SendParentAction = wrapParserResult(
   namedFunctionCall("sendParent", AnyNode),
-  (result, node, context): ActionNode => {
+  (result, path, context): ActionNode => {
     return {
+      path,
       node: result.node,
       action: sendParent(""),
       name: "",
       declarationType: "inline",
-      inlineDeclarationId: context.getNodeHash(node),
+      inlineDeclarationId: context.getNodeHash(result.node),
     };
-  },
+  }
 );
 
 export const SendUpdateAction = wrapParserResult(
   namedFunctionCall("sendUpdate", AnyNode),
-  (result, node, context): ActionNode => {
+  (result, path, context): ActionNode => {
     return {
+      path,
       node: result.node,
       action: sendUpdate(),
       name: "",
       declarationType: "inline",
-      inlineDeclarationId: context.getNodeHash(node),
+      inlineDeclarationId: context.getNodeHash(result.node),
     };
-  },
+  }
 );
 
 export const StartAction = wrapParserResult(
   namedFunctionCall("start", AnyNode),
-  (result, node, context): ActionNode => {
+  (result, path, context): ActionNode => {
     return {
+      path,
       node: result.node,
       action: start(""),
       name: "",
       declarationType: "inline",
-      inlineDeclarationId: context.getNodeHash(node),
+      inlineDeclarationId: context.getNodeHash(result.node),
     };
-  },
+  }
 );
 
 export const StopAction = wrapParserResult(
   namedFunctionCall("stop", AnyNode),
-  (result, node, context): ActionNode => {
+  (result, path, context): ActionNode => {
     return {
+      path,
       node: result.node,
       action: stop(""),
       name: "",
       declarationType: "inline",
-      inlineDeclarationId: context.getNodeHash(node),
+      inlineDeclarationId: context.getNodeHash(result.node),
     };
-  },
+  }
 );

--- a/packages/machine-extractor/src/parseMachinesFromFile.ts
+++ b/packages/machine-extractor/src/parseMachinesFromFile.ts
@@ -58,7 +58,7 @@ export const parseMachinesFromFile = (fileContents: string): ParseResult => {
 
   traverse(parseResult as any, {
     CallExpression(path) {
-      const ast = MachineCallExpression.parse(path.node as any, {
+      const ast = MachineCallExpression.parse(path, {
         file: parseResult,
         getNodeHash: getNodeHash,
       });

--- a/packages/machine-extractor/src/scalars.ts
+++ b/packages/machine-extractor/src/scalars.ts
@@ -21,7 +21,7 @@ export const StringLiteral = unionType([
     maybeIdentifierTo(
       createParser({
         babelMatcher: t.isStringLiteral,
-        parseNode: (path): StringLiteralNode => {
+        extract: (path): StringLiteralNode => {
           return {
             value: path.node.value,
             node: path.node,
@@ -37,7 +37,7 @@ export const NumericLiteral = maybeTsAsExpression(
   maybeIdentifierTo(
     createParser({
       babelMatcher: t.isNumericLiteral,
-      parseNode: (path) => {
+      extract: (path) => {
         return {
           value: path.node.value,
           node: path.node,
@@ -52,7 +52,7 @@ export const BooleanLiteral = maybeTsAsExpression(
   maybeIdentifierTo(
     createParser({
       babelMatcher: t.isBooleanLiteral,
-      parseNode: (path) => {
+      extract: (path) => {
         return {
           value: path.node.value,
           node: path.node,
@@ -65,19 +65,19 @@ export const BooleanLiteral = maybeTsAsExpression(
 
 export const AnyNode = createParser({
   babelMatcher: t.isNode,
-  parseNode: (path) => ({ path, node: path.node }),
+  extract: (path) => ({ path, node: path.node }),
 });
 
 export const Identifier = createParser({
   babelMatcher: t.isIdentifier,
-  parseNode: (path) => ({ path, node: path.node }),
+  extract: (path) => ({ path, node: path.node }),
 });
 
 export const TemplateLiteral = maybeTsAsExpression(
   maybeIdentifierTo(
     createParser({
       babelMatcher: t.isTemplateLiteral,
-      parseNode: (path) => {
+      extract: (path) => {
         let value = "";
 
         // TODO - this might lead to weird issues if there is actually more than a single quasi there

--- a/packages/machine-extractor/src/scalars.ts
+++ b/packages/machine-extractor/src/scalars.ts
@@ -4,30 +4,32 @@ import {
   maybeIdentifierTo,
   memberExpressionReferencingEnumMember,
 } from "./identifiers";
-import { StringLiteralNode } from "./types";
 import { maybeTsAsExpression } from "./tsAsExpression";
+import { StringLiteralNode } from "./types";
 import { unionType } from "./unionType";
 import { wrapParserResult } from "./wrapParserResult";
 
 export const StringLiteral = unionType([
-  wrapParserResult(memberExpressionReferencingEnumMember, (node) => {
+  wrapParserResult(memberExpressionReferencingEnumMember, ({ path, value }) => {
     return {
-      node: node.node as t.Node,
-      value: node.value,
+      path,
+      node: path.node as t.Node,
+      value: value,
     };
   }),
   maybeTsAsExpression(
     maybeIdentifierTo(
       createParser({
         babelMatcher: t.isStringLiteral,
-        parseNode: (node): StringLiteralNode => {
+        parseNode: (path): StringLiteralNode => {
           return {
-            value: node.value,
-            node,
+            value: path.node.value,
+            node: path.node,
+            path,
           };
         },
-      }),
-    ),
+      })
+    )
   ),
 ]);
 
@@ -35,56 +37,59 @@ export const NumericLiteral = maybeTsAsExpression(
   maybeIdentifierTo(
     createParser({
       babelMatcher: t.isNumericLiteral,
-      parseNode: (node) => {
+      parseNode: (path) => {
         return {
-          value: node.value,
-          node,
+          value: path.node.value,
+          node: path.node,
+          path,
         };
       },
-    }),
-  ),
+    })
+  )
 );
 
 export const BooleanLiteral = maybeTsAsExpression(
   maybeIdentifierTo(
     createParser({
       babelMatcher: t.isBooleanLiteral,
-      parseNode: (node) => {
+      parseNode: (path) => {
         return {
-          value: node.value,
-          node,
+          value: path.node.value,
+          node: path.node,
+          path,
         };
       },
-    }),
-  ),
+    })
+  )
 );
 
 export const AnyNode = createParser({
   babelMatcher: t.isNode,
-  parseNode: (node) => ({ node }),
+  parseNode: (path) => ({ path, node: path.node }),
 });
 
 export const Identifier = createParser({
   babelMatcher: t.isIdentifier,
-  parseNode: (node) => ({ node }),
+  parseNode: (path) => ({ path, node: path.node }),
 });
 
 export const TemplateLiteral = maybeTsAsExpression(
   maybeIdentifierTo(
     createParser({
       babelMatcher: t.isTemplateLiteral,
-      parseNode: (node) => {
+      parseNode: (path) => {
         let value = "";
 
         // TODO - this might lead to weird issues if there is actually more than a single quasi there
-        node.quasis.forEach((quasi) => {
+        path.node.quasis.forEach((quasi) => {
           value = `${value}${quasi.value.raw}`;
         });
         return {
-          node,
+          node: path.node,
+          path,
           value,
         };
       },
-    }),
-  ),
+    })
+  )
 );

--- a/packages/machine-extractor/src/tsAsExpression.ts
+++ b/packages/machine-extractor/src/tsAsExpression.ts
@@ -1,14 +1,14 @@
-import { AnyParser } from ".";
 import { types as t } from "@babel/core";
+import { AnyParser } from ".";
 import { createParser } from "./createParser";
 import { unionType } from "./unionType";
 
 export const tsAsExpression = <Result>(parser: AnyParser<Result>) => {
   return createParser({
     babelMatcher: t.isTSAsExpression,
-    parseNode: (node, context) => {
-      if (parser.matches(node.expression)) {
-        return parser.parse(node.expression, context);
+    parseNode: (path, context) => {
+      if (parser.matches(path.get("expression")?.node)) {
+        return parser.parse(path.get("expression"), context);
       }
     },
   });

--- a/packages/machine-extractor/src/tsAsExpression.ts
+++ b/packages/machine-extractor/src/tsAsExpression.ts
@@ -6,7 +6,7 @@ import { unionType } from "./unionType";
 export const tsAsExpression = <Result>(parser: AnyParser<Result>) => {
   return createParser({
     babelMatcher: t.isTSAsExpression,
-    parseNode: (path, context) => {
+    extract: (path, context) => {
       if (parser.matches(path.get("expression")?.node)) {
         return parser.parse(path.get("expression"), context);
       }

--- a/packages/machine-extractor/src/typeParameters.ts
+++ b/packages/machine-extractor/src/typeParameters.ts
@@ -7,10 +7,11 @@ export const TSTypeParameterInstantiation = <Result>(
 ) =>
   createParser({
     babelMatcher: t.isTSTypeParameterInstantiation,
-    parseNode: (node, context) => {
+    parseNode: (path, context) => {
       return {
-        node,
-        params: node.params.map((param) => parser.parse(param, context)),
+        path,
+        node: path.node,
+        params: path.get("params").map((param) => parser.parse(param, context)),
       };
     },
   });

--- a/packages/machine-extractor/src/typeParameters.ts
+++ b/packages/machine-extractor/src/typeParameters.ts
@@ -7,7 +7,7 @@ export const TSTypeParameterInstantiation = <Result>(
 ) =>
   createParser({
     babelMatcher: t.isTSTypeParameterInstantiation,
-    parseNode: (path, context) => {
+    extract: (path, context) => {
       return {
         path,
         node: path.node,
@@ -18,7 +18,7 @@ export const TSTypeParameterInstantiation = <Result>(
 
 export const TSType = createParser({
   babelMatcher: t.isTSType,
-  parseNode: (node) => {
+  extract: (node) => {
     return {
       node,
     };

--- a/packages/machine-extractor/src/types.ts
+++ b/packages/machine-extractor/src/types.ts
@@ -1,5 +1,4 @@
-import { types as t } from "@babel/core";
-import { MachineConfig } from "xstate";
+import { NodePath, types as t } from "@babel/core";
 import { MachineParseResult } from "./MachineParseResult";
 
 export type Location = t.SourceLocation | null;
@@ -7,6 +6,7 @@ export type Location = t.SourceLocation | null;
 export interface StringLiteralNode {
   value: string;
   node: t.Node;
+  path: NodePath<t.Node>;
 }
 
 export interface ParserContext {
@@ -16,15 +16,18 @@ export interface ParserContext {
 
 export interface Parser<T extends t.Node = any, Result = any> {
   parse: (
-    node: t.Node | undefined | null,
-    context: ParserContext,
+    node: NodePath<T | undefined | null> | undefined | null,
+    context: ParserContext
   ) => Result | undefined;
-  matches: (node: T) => boolean;
+  matches: (node: t.Node) => boolean;
 }
 
 export interface AnyParser<Result> {
-  parse: (node: any, context: ParserContext) => Result | undefined;
-  matches: (node: any) => boolean;
+  parse: (
+    node: NodePath<any> | null | undefined,
+    context: ParserContext
+  ) => Result | undefined;
+  matches: (node: t.Node) => boolean;
 }
 
 export interface Comment {

--- a/packages/machine-extractor/src/unionType.ts
+++ b/packages/machine-extractor/src/unionType.ts
@@ -6,15 +6,17 @@ import { AnyParser, ParserContext } from ".";
  * return the same result
  */
 export const unionType = <Result>(
-  parsers: AnyParser<Result>[],
+  parsers: AnyParser<Result>[]
 ): AnyParser<Result> => {
   const matches = (node: any) => {
     return parsers.some((parser) => parser.matches(node));
   };
-  const parse = (node: any, context: ParserContext): Result | undefined => {
-    const possibleParsers = parsers.filter((parser) => parser.matches(node));
+  const parse = (path: any, context: ParserContext): Result | undefined => {
+    const possibleParsers = parsers.filter((parser) =>
+      parser.matches(path?.node)
+    );
     for (const parser of possibleParsers) {
-      const result = parser.parse(node, context);
+      const result = parser.parse(path, context);
       if (result) return result;
     }
   };

--- a/packages/machine-extractor/src/utils.ts
+++ b/packages/machine-extractor/src/utils.ts
@@ -17,7 +17,7 @@ import { wrapParserResult } from "./wrapParserResult";
 
 export const parserFromBabelMatcher = <T extends t.Node>(
   babelMatcher: (node: any) => node is T
-) => createParser({ babelMatcher, parseNode: (node) => node });
+) => createParser({ babelMatcher, extract: (node) => node });
 
 /**
  * Useful for when something might, or might not,
@@ -28,7 +28,7 @@ export const maybeArrayOf = <Result>(
 ): AnyParser<Result[]> => {
   const arrayParser = createParser({
     babelMatcher: t.isArrayExpression,
-    parseNode: (path, context) => {
+    extract: (path, context) => {
       const toReturn: Result[] = [];
 
       path.get("elements").map((elem) => {
@@ -66,7 +66,7 @@ export const arrayOf = <Result>(
 ): AnyParser<Result[]> => {
   return createParser({
     babelMatcher: t.isArrayExpression,
-    parseNode: (path, context) => {
+    extract: (path, context) => {
       const toReturn: Result[] = [];
 
       path.get("elements").map((elem) => {
@@ -83,7 +83,7 @@ export const arrayOf = <Result>(
 
 export const objectMethod = createParser({
   babelMatcher: t.isObjectMethod,
-  parseNode: (path, context) => {
+  extract: (path, context) => {
     return {
       node: path.node,
       path,
@@ -110,7 +110,7 @@ export const staticObjectProperty = <KeyResult>(
     babelMatcher: (node): node is t.ObjectProperty => {
       return t.isObjectProperty(node) && !node.computed;
     },
-    parseNode: (path, context) => {
+    extract: (path, context) => {
       return {
         node: path.node,
         path,
@@ -122,7 +122,7 @@ export const staticObjectProperty = <KeyResult>(
 export const spreadElement = <Result>(parser: AnyParser<Result>) => {
   return createParser({
     babelMatcher: t.isSpreadElement,
-    parseNode: (path, context) => {
+    extract: (path, context) => {
       const result = {
         node: path.node,
         path,
@@ -154,7 +154,7 @@ export const dynamicObjectProperty = <KeyResult>(
     babelMatcher: (node): node is t.ObjectProperty => {
       return t.isObjectProperty(node) && node.computed;
     },
-    parseNode: (path, context) => {
+    extract: (path, context) => {
       return {
         node: path.node,
         path,
@@ -167,7 +167,7 @@ const staticPropertyWithKey = staticObjectProperty(
   unionType<{ node: t.Node; path: NodePath<t.Node>; value: string | number }>([
     createParser({
       babelMatcher: t.isIdentifier,
-      parseNode: (path) => {
+      extract: (path) => {
         return {
           node: path.node,
           path,
@@ -226,7 +226,7 @@ export const getPropertiesOfObjectExpression = (
     const spreadElementResult = spreadElementReferencingIdentifier(
       createParser({
         babelMatcher: t.isObjectExpression,
-        parseNode: (path) => path,
+        extract: (path) => path,
       })
     ).parse(property as any, context);
 
@@ -288,7 +288,7 @@ export const objectTypeWithKnownKeys = <
     maybeIdentifierTo(
       createParser<t.ObjectExpression, GetObjectKeysResult<T>>({
         babelMatcher: t.isObjectExpression,
-        parseNode: (path, context) => {
+        extract: (path, context) => {
           const properties = getPropertiesOfObjectExpression(path, context);
 
           const parseObject =
@@ -349,7 +349,7 @@ export const objectOf = <Result>(
   return maybeIdentifierTo(
     createParser({
       babelMatcher: t.isObjectExpression,
-      parseNode: (path, context) => {
+      extract: (path, context) => {
         const properties = getPropertiesOfObjectExpression(path, context);
 
         const toReturn = {
@@ -399,7 +399,7 @@ export const namedFunctionCall = <Argument1Result, Argument2Result>(
     maybeIdentifierTo(
       createParser({
         babelMatcher: t.isCallExpression,
-        parseNode: (node) => {
+        extract: (node) => {
           return node;
         },
       })
@@ -430,7 +430,7 @@ export const namedFunctionCall = <Argument1Result, Argument2Result>(
 
       return node.callee.name === name;
     },
-    parseNode: (path, context) => {
+    extract: (path, context) => {
       return {
         node: path.node,
         path: path,

--- a/packages/machine-extractor/src/utils.ts
+++ b/packages/machine-extractor/src/utils.ts
@@ -307,14 +307,14 @@ export const objectTypeWithKnownKeys = <
 
             let result: any | undefined;
 
-            if (t.isObjectMethod(property.node)) {
+            if (property.path.isObjectMethod()) {
               result = parser.parse(property.path, context);
-            } else if (t.isObjectProperty(property.node)) {
+            } else if (property.path.isObjectProperty()) {
               result = parser.parse(
                 (property.path as NodePath<t.ObjectProperty>).get("value"),
                 context
               );
-              if (result) {
+              if (result && "value" in property.node) {
                 result._valueNode = property.node.value;
               }
             }

--- a/packages/machine-extractor/src/wrapParserResult.ts
+++ b/packages/machine-extractor/src/wrapParserResult.ts
@@ -1,4 +1,4 @@
-import { types as t } from "@babel/core";
+import { NodePath, types as t } from "@babel/core";
 import { ParserContext } from ".";
 import { AnyParser } from "./types";
 
@@ -10,16 +10,16 @@ export const wrapParserResult = <T extends t.Node, Result, NewResult>(
   parser: AnyParser<Result>,
   changeResult: (
     result: Result,
-    node: T,
-    context: ParserContext,
-  ) => NewResult | undefined,
+    path: NodePath<T>,
+    context: ParserContext
+  ) => NewResult | undefined
 ): AnyParser<NewResult> => {
   return {
     matches: parser.matches,
-    parse: (node: any, context) => {
-      const result = parser.parse(node, context);
+    parse: (path: NodePath<any> | null | undefined, context) => {
+      const result = parser.parse(path, context);
       if (!result) return undefined;
-      return changeResult(result, node, context);
+      return changeResult(result, path!, context);
     },
   };
 };


### PR DESCRIPTION
This PR picks up on #174 by breaking out its first two commits into a separate PR. This is a solid refactor and is worth separating from the `recast` experiment stuff in order to get it merged sooner.

I made two changes from @mattpocock's original work:

- renamed `parseNode` to `extract` [based on feedback from @Andarist](https://github.com/statelyai/xstate-tools/pull/174#discussion_r913563834)
 
  I thought about it quite a bit and I'm still not sure that word is the most accurate, but it feels better than `parsePath` or `collect` at least

- used `property.path.isX()` for better type narrowing [based on feedback from @Andarist](https://github.com/statelyai/xstate-tools/pull/174#discussion_r913580038)