### PR TITLE
Make xstate-layout string placement more robust to changes

### DIFF
--- a/apps/extension/client/testFixture/machine.ts
+++ b/apps/extension/client/testFixture/machine.ts
@@ -1,6 +1,5 @@
 import { createMachine } from 'xstate';
 
-/** @xstate-layout N4IgpgJg5mDOIC5gF8A0IB2B7CdGgAoBbAQwGMALASwzAEoA6KiAGzHxAActYqAXKlgwcAHogAsAJnQBPRAA4ArA3EBOdYtUBmAAyr5qxfPHI0IYuWq06HbrwFDRiAIzzZL+Qx3efv3wHZTUyA */
 createMachine(
   {
     id: '(machine)',
@@ -8,12 +7,13 @@ createMachine(
     states: {
       idle: {
         on: {
-          NEXT: 'active',
+          NEXT: {
+            target: 'active',
+            cond: 'canGoNext',
+          },
         },
       },
-
       active: {},
-      'new state 1': {},
     },
   },
   {

--- a/apps/extension/client/testFixture/machine.ts
+++ b/apps/extension/client/testFixture/machine.ts
@@ -8,13 +8,12 @@ createMachine(
     states: {
       idle: {
         on: {
-          NEXT: {
-            target: 'active',
-            cond: 'canGoNext',
-          },
+          NEXT: 'active',
         },
       },
+
       active: {},
+      'new state 1': {},
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "deps:build": "preconstruct build",
     "vscode:dev": "yarn turbo run vscode:build:dev --no-cache && cp apps/extension/server/dist/index.js apps/extension/client/dist/server.js",
     "vscode:prod": "yarn turbo run vscode:build:prod --no-cache && cp apps/extension/server/dist/index.js apps/extension/client/dist/server.js",
-    "test": "jest"
+    "test": "jest",
+    "build:vsix": "cd apps/extension/client && npx vsce package --yarn"
   },
   "preconstruct": {
     "packages": [

--- a/packages/machine-extractor/src/MachineExtractResult.ts
+++ b/packages/machine-extractor/src/MachineExtractResult.ts
@@ -4,12 +4,12 @@ import * as recast from 'recast';
 import { Action, Condition, MachineOptions } from 'xstate';
 import { choose } from 'xstate/lib/actions';
 import { DeclarationType } from '.';
+import { RecordOfArrays } from './RecordOfArrays';
 import { ActionNode, ParsedChooseCondition } from './actions';
 import { getMachineNodesFromFile } from './getMachineNodesFromFile';
 import { TMachineCallExpression } from './machineCallExpression';
-import { RecordOfArrays } from './RecordOfArrays';
 import { StateNodeReturn } from './stateNode';
-import { toMachineConfig, ToMachineConfigOptions } from './toMachineConfig';
+import { ToMachineConfigOptions, toMachineConfig } from './toMachineConfig';
 import { TransitionConfigNode } from './transitions';
 import { Comment } from './types';
 
@@ -338,10 +338,10 @@ export class MachineExtractResult {
         return false;
       }
 
-      return (
-        comment.loc!.end.line ===
-        this.machineCallResult.callee.loc!.start.line - 1
-      );
+      const proximity =
+        this.machineCallResult.callee.loc!.start.line - comment.loc!.end.line;
+
+      return proximity < 5;
     });
 
     if (!layoutComment) return undefined;

--- a/packages/machine-extractor/src/MachineExtractResult.ts
+++ b/packages/machine-extractor/src/MachineExtractResult.ts
@@ -341,7 +341,7 @@ export class MachineExtractResult {
       const proximity =
         this.machineCallResult.callee.loc!.start.line - comment.loc!.end.line;
 
-      return proximity < 5;
+      return Math.abs(proximity) <= 2;
     });
 
     if (!layoutComment) return undefined;

--- a/packages/machine-extractor/src/__tests__/layout-comment.test.ts
+++ b/packages/machine-extractor/src/__tests__/layout-comment.test.ts
@@ -11,4 +11,43 @@ describe('Layout comments', () => {
       `layout-string`,
     );
   });
+
+  it('Should parse layout comments that appear after the variable declaration', () => {
+    const result = extractMachinesFromFile(`
+      const machine =
+      /** @xstate-layout layout-string */
+      createMachine({});
+    `);
+
+    expect(result!.machines[0]!.getLayoutComment()?.value).toEqual(
+      `layout-string`,
+    );
+  });
+
+  it('Should parse layout comments that are near variable declaration', () => {
+    const result = extractMachinesFromFile(`
+      const machine =
+      /** @xstate-layout layout-string */
+      
+      createMachine({});
+    `);
+
+    expect(result!.machines[0]!.getLayoutComment()?.value).toEqual(
+      `layout-string`,
+    );
+  });
+
+  it('Should not parse layout comments that are far from machine', () => {
+    const result = extractMachinesFromFile(`
+      /** @xstate-layout layout-string */
+      
+
+
+
+
+      const machine = createMachine({});
+    `);
+
+    expect(result!.machines[0]!.getLayoutComment()?.value).toBeUndefined();
+  });
 });


### PR DESCRIPTION
This PR ensures that the machine extractor will detect the layout string even if it's not directly above the const declaration. This potentially solves the multiple layout string issues found here:

- https://discord.com/channels/795785288994652170/912333666456313907/1061523294056108042