### PR TITLE
Use `predictableActionArguments` flag in the `createIntrospectableMachine` to avoid spurious warnings

### DIFF
--- a/.changeset/large-ladybugs-warn.md
+++ b/.changeset/large-ladybugs-warn.md
@@ -1,0 +1,6 @@
+---
+'@xstate/tools-shared': patch
+'@xstate/cli': patch
+---
+
+Fixed an issue with a misleading dev-only warning being printed when generating typegen data because of the internal `createMachine` call.

--- a/packages/shared/src/createIntrospectableMachine.ts
+++ b/packages/shared/src/createIntrospectableMachine.ts
@@ -18,6 +18,7 @@ export function createIntrospectableMachine(
     {
       ...machineResult.toConfig(),
       context: {},
+      predictableActionArguments: true,
     },
     {
       guards: stubAllWith(() => false),


### PR DESCRIPTION
closes https://github.com/statelyai/xstate/issues/3759