### PR TITLE
Prefer inserting an inner layout comment

### DIFF
--- a/.changeset/perfect-queens-bow.md
+++ b/.changeset/perfect-queens-bow.md
@@ -1,0 +1,6 @@
+---
+'@xstate/machine-extractor': patch
+'stately-vscode': minor
+---
+
+Changed the default location for the layout string insertion to be **within** the machine config (before its first property).

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     "source.fixAll.eslint": true,
     "source.sortImports": true
   },
+  "npm.packageManager": "yarn",
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/apps/extension/server/src/server.ts
+++ b/apps/extension/server/src/server.ts
@@ -36,7 +36,12 @@ import { getCursorHoverType } from './getCursorHoverType';
 import { getDiagnostics } from './getDiagnostics';
 import { getReferences } from './getReferences';
 import { CachedDocument } from './types';
-import { getErrorMessage, isTypedMachineResult, isTypegenData } from './utils';
+import {
+  getErrorMessage,
+  isTypedMachineResult,
+  isTypegenData,
+  mergeOverlappingEdits,
+} from './utils';
 
 let hasConfigurationCapability = false;
 let hasWorkspaceFolderCapability = false;
@@ -787,11 +792,12 @@ connection.onRequest('applyMachineEdits', ({ machineEdits, reason }) => {
       );
     }
   }
-
-  const edits = [
-    modified.configEdit,
-    'layoutEdit' in modified ? modified.layoutEdit : undefined,
-  ].filter((edit): edit is NonNullable<typeof edit> => !!edit);
+  const edits = mergeOverlappingEdits(
+    [
+      modified.configEdit,
+      'layoutEdit' in modified ? modified.layoutEdit : undefined,
+    ].filter((edit): edit is NonNullable<typeof edit> => !!edit),
+  );
 
   let newDocumentText = cachedDocument.documentText;
 

--- a/apps/extension/server/src/utils.ts
+++ b/apps/extension/server/src/utils.ts
@@ -1,5 +1,5 @@
 import { MachineExtractResult } from '@xstate/machine-extractor';
-import { TypegenData } from '@xstate/tools-shared';
+import { TextEdit, TypegenData } from '@xstate/tools-shared';
 
 export const getErrorMessage = (error: unknown): string => {
   if (
@@ -19,3 +19,35 @@ export const isTypegenData = (
 
 export const isTypedMachineResult = (machineResult: MachineExtractResult) =>
   machineResult.machineCallResult.definition?.tsTypes?.node !== undefined;
+
+// this assumes that the latter (layout) edit might be contained in the previous edit (config)
+// it doesn't handle the reverse case
+export const mergeOverlappingEdits = (edits: TextEdit[]): TextEdit[] => {
+  const mergedEdits: TextEdit[] = [];
+
+  for (const edit of edits) {
+    const existingEdit = mergedEdits.find(
+      (otherEdit) =>
+        edit.range[0].index >= otherEdit.range[0].index &&
+        edit.range[1].index <= otherEdit.range[1].index,
+    );
+
+    if (!existingEdit) {
+      mergedEdits.push(edit);
+      continue;
+    }
+
+    const oldLength = edit.range[1].index - edit.range[0].index;
+
+    const newTextStart = edit.range[0].index - existingEdit.range[0].index;
+
+    // we only mutate the `newText` because `range` refers to positions in the old source code
+    // and we still want to affect the same old range
+    existingEdit.newText =
+      existingEdit.newText.slice(0, newTextStart) +
+      edit.newText +
+      existingEdit.newText.slice(newTextStart + oldLength);
+  }
+
+  return mergedEdits;
+};

--- a/packages/machine-extractor/src/MachineExtractResult.ts
+++ b/packages/machine-extractor/src/MachineExtractResult.ts
@@ -1537,17 +1537,20 @@ export class MachineExtractResult {
               };
               break;
             }
+            const indentation = consumeIndentationToNodeAtIndex(
+              this._fileContent,
+              definitionNode.properties[0]?.start,
+            );
             const insidePosition = {
               line: definitionNode.loc!.start.line - 1,
               column: definitionNode.loc!.start.column + 1,
               index: definitionNode.start! + 1,
             } as const;
-
             layoutEdit = {
               // this is used as a replace but it could be a simpler~ insertion
               type: 'replace',
               range: [insidePosition, insidePosition],
-              newText: `\n/** @xstate-layout ${edit.layoutString} */`,
+              newText: `\n${indentation}/** @xstate-layout ${edit.layoutString} */`,
             };
             break;
           }
@@ -2768,4 +2771,28 @@ function getStatesObjectInState(stateObj: RecastObjectExpression) {
   const statesObj = b.objectExpression([]);
   stateObj.properties.push(b.objectProperty(b.identifier('states'), statesObj));
   return statesObj;
+}
+
+function consumeIndentationToNodeAtIndex(
+  fileContent: string,
+  index: number | null | undefined,
+) {
+  if (typeof index !== 'number') {
+    return '';
+  }
+  let indentation = '';
+  let i = index;
+  while (true) {
+    index--;
+    const char = fileContent[index];
+
+    if (char === '\n') {
+      return indentation;
+    }
+
+    if (!/\s/.test(char)) {
+      return '';
+    }
+    indentation = `${char}${indentation}`;
+  }
 }

--- a/packages/machine-extractor/src/MachineExtractResult.ts
+++ b/packages/machine-extractor/src/MachineExtractResult.ts
@@ -1547,7 +1547,7 @@ export class MachineExtractResult {
               // this is used as a replace but it could be a simpler~ insertion
               type: 'replace',
               range: [insidePosition, insidePosition],
-              newText: `\n/** @xstate-layout ${edit.layoutString} */\n`,
+              newText: `\n/** @xstate-layout ${edit.layoutString} */`,
             };
             break;
           }


### PR DESCRIPTION
STA-2082

The layout string will only be inserted inside the machine when there is no existing layout machine - and of course, once it's inside it will be updated there.

For the time being, I decided to avoid "migrating" the old placement to the new one. This would create big diffs in projects as the machine config is almost guaranteed to be dedented after a such change and that could get in people's way during code reviews etc. We could consider making this configurable or something but let's start simple.