### PR TITLE
Add `useDeclarationFileForTypegenData` option

### DIFF
--- a/.changeset/wise-mangos-cover.md
+++ b/.changeset/wise-mangos-cover.md
@@ -1,0 +1,10 @@
+---
+'stately-vscode': minor
+---
+
+author: @andreash
+author: @Andarist
+
+Introduced a new opt-in option `useDeclarationFileForTypegenData`. It's the recommended way of using this extension and typegen and it fixes compatibility with modern `moduleResolution` options in TypeScript. It can also help you to avoid issues in frameworks that derive pages based on the directory content (such as Nuxt).
+
+Enabling this might require using at least TypeScript 5.0.

--- a/apps/extension/client/package.json
+++ b/apps/extension/client/package.json
@@ -68,10 +68,10 @@
           "default": true,
           "description": "Enable nesting the generated typegen files."
         },
-        "xstate.appendJSToTypegenImport": {
+        "xstate.useDeclarationFileForTypegenData": {
           "type": "boolean",
           "default": false,
-          "description": "Append .js extension to TypeGen import to satisfy ESM environments."
+          "description": "Generate typegen data into `.d.ts` files and use this extension in the import's source that refers to it."
         },
         "xstate.theme": {
           "type": "string",

--- a/apps/extension/client/package.json
+++ b/apps/extension/client/package.json
@@ -68,6 +68,11 @@
           "default": true,
           "description": "Enable nesting the generated typegen files."
         },
+        "xstate.appendJSToTypegenImport": {
+          "type": "boolean",
+          "default": false,
+          "description": "Append .js extension to TypeGen import to satisfy ESM environments."
+        },
         "xstate.theme": {
           "type": "string",
           "enum": [

--- a/apps/extension/server/src/server.ts
+++ b/apps/extension/server/src/server.ts
@@ -234,7 +234,6 @@ async function handleDocumentChange(textDocument: TextDocument): Promise<void> {
     ]);
 
     const extractionResults = machineResults.map((machineResult, index) => {
-      console.log({ settings, t: 'asdf' });
       try {
         if (isTypedMachineResult(machineResult)) {
           // Create typegen data for typed machines. This will throw if there are any errors.

--- a/apps/extension/server/src/server.ts
+++ b/apps/extension/server/src/server.ts
@@ -48,6 +48,7 @@ let hasWorkspaceFolderCapability = false;
 
 const defaultSettings: GlobalSettings = {
   showVisualEditorWarnings: true,
+  appendJSToTypegenImport: false,
 };
 let globalSettings: GlobalSettings = defaultSettings;
 
@@ -233,6 +234,7 @@ async function handleDocumentChange(textDocument: TextDocument): Promise<void> {
     ]);
 
     const extractionResults = machineResults.map((machineResult, index) => {
+      console.log({ settings, t: 'asdf' });
       try {
         if (isTypedMachineResult(machineResult)) {
           // Create typegen data for typed machines. This will throw if there are any errors.
@@ -242,6 +244,7 @@ async function handleDocumentChange(textDocument: TextDocument): Promise<void> {
               UriUtils.basename(URI.parse(textDocument.uri)),
               index,
               machineResult,
+              settings,
             ),
           };
         } else {

--- a/apps/extension/server/src/server.ts
+++ b/apps/extension/server/src/server.ts
@@ -18,6 +18,7 @@ import {
   introspectMachine,
   isCursorInPosition,
   TypegenData,
+  TypegenOptions,
 } from '@xstate/tools-shared';
 import deepEqual from 'fast-deep-equal';
 import { CodeLens, Position } from 'vscode-languageserver';
@@ -43,12 +44,26 @@ import {
   mergeOverlappingEdits,
 } from './utils';
 
+const getTypegenUri = (
+  uri: string,
+  { useDeclarationFileForTypegenData }: TypegenOptions,
+) => {
+  const parsedUri = URI.parse(uri);
+  return parsedUri
+    .with({
+      path:
+        parsedUri.path.slice(0, -UriUtils.extname(parsedUri).length) +
+        `.typegen${useDeclarationFileForTypegenData ? '.d' : ''}.ts`,
+    })
+    .toString();
+};
+
 let hasConfigurationCapability = false;
 let hasWorkspaceFolderCapability = false;
 
 const defaultSettings: GlobalSettings = {
   showVisualEditorWarnings: true,
-  appendJSToTypegenImport: false,
+  useDeclarationFileForTypegenData: false,
 };
 let globalSettings: GlobalSettings = defaultSettings;
 
@@ -371,7 +386,7 @@ async function handleDocumentChange(textDocument: TextDocument): Promise<void> {
       )
     ) {
       connection.sendNotification('typesUpdated', {
-        uri: textDocument.uri,
+        typegenUri: getTypegenUri(textDocument.uri, settings),
         types,
       });
     }
@@ -413,9 +428,8 @@ connection.onDidChangeConfiguration((change) => {
   if (hasConfigurationCapability) {
     documentSettings.clear();
   } else {
-    globalSettings = <GlobalSettings>(
-      (change.settings.languageServerExample || defaultSettings)
-    );
+    globalSettings =
+      (change.settings.xstate as GlobalSettings) || defaultSettings;
   }
 
   connection.documents.all().forEach(handleDocumentChange);
@@ -831,18 +845,16 @@ connection.onRequest('applyMachineEdits', ({ machineEdits, reason }) => {
   };
 });
 
-connection.onRequest('getTsTypesAndEdits', ({ uri }) => {
+connection.onRequest('getTsTypesAndEdits', async ({ uri }) => {
   const cachedDocument = documentsCache.get(uri);
   if (!cachedDocument) {
-    return {
-      types: [],
-      edits: [],
-    };
+    return;
   }
   const types = cachedDocument.extractionResults
     .map((extractionResult) => extractionResult.types)
     .filter(isTypegenData);
   return {
+    typegenUri: getTypegenUri(uri, await getDocumentSettings(uri)),
     types,
     edits: getTsTypesEdits(types).map((edit) => ({
       type: 'replace',

--- a/packages/shared/src/getTypegenData.ts
+++ b/packages/shared/src/getTypegenData.ts
@@ -1,7 +1,7 @@
 import { MachineExtractResult } from '@xstate/machine-extractor';
 import { createIntrospectableMachine } from './createIntrospectableMachine';
 import { introspectMachine } from './introspectMachine';
-
+import { GlobalSettings } from './types';
 export interface TypegenData extends ReturnType<typeof getTypegenData> {}
 
 const removeExtension = (fileName: string) => fileName.replace(/\.[^/.]+$/, '');
@@ -12,6 +12,7 @@ export const getTypegenData = (
   fileName: string,
   machineIndex: number,
   machineResult: MachineExtractResult,
+  settings: GlobalSettings,
 ) => {
   const introspectResult = introspectMachine(
     createIntrospectableMachine(machineResult) as any,
@@ -32,6 +33,8 @@ export const getTypegenData = (
   const services = introspectResult.services.lines.filter(
     (line) => !line.name.startsWith('xstate.'),
   );
+
+  const extension = settings.appendJSToTypegenImport ? '.js' : '';
 
   const allServices =
     machineResult
@@ -65,7 +68,7 @@ export const getTypegenData = (
     // we sort strings here because we use deep comparison to detect a change in the output of this function
     data: {
       tsTypesValue: {
-        argument: `./${removeExtension(fileName)}.typegen`,
+        argument: `./${removeExtension(fileName)}.typegen${extension}`,
         qualifier: `Typegen${machineIndex}`,
       },
       internalEvents: collectPotentialInternalEvents(

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -2,9 +2,12 @@ import { MachineEdit } from '@xstate/machine-extractor';
 import { MachineConfig } from 'xstate';
 import { TypegenData } from './getTypegenData';
 
-export interface GlobalSettings {
+export interface TypegenOptions {
+  useDeclarationFileForTypegenData: boolean;
+}
+
+export interface GlobalSettings extends TypegenOptions {
   showVisualEditorWarnings: boolean;
-  appendJSToTypegenImport: boolean;
 }
 
 export interface SourceLocation {
@@ -88,10 +91,13 @@ export interface RequestMap {
   };
   getTsTypesAndEdits: {
     params: { uri: string };
-    result: {
-      types: TypegenData[];
-      edits: Array<FileTextEdit>;
-    };
+    result:
+      | {
+          typegenUri: string;
+          types: TypegenData[];
+          edits: Array<FileTextEdit>;
+        }
+      | undefined;
     error: never;
   };
   getNodePosition: {
@@ -119,7 +125,7 @@ export interface NotificationMap {
     namedGuards: string[];
   };
   typesUpdated: {
-    uri: string;
+    typegenUri: string;
     types: TypegenData[];
   };
   extractionError: {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -4,6 +4,7 @@ import { TypegenData } from './getTypegenData';
 
 export interface GlobalSettings {
   showVisualEditorWarnings: boolean;
+  appendJSToTypegenImport: boolean;
 }
 
 export interface SourceLocation {


### PR DESCRIPTION
This is with respect to the discussion [here](https://github.com/statelyai/xstate/discussions/3933#discussioncomment-5626905) and introduces an option to append ".js" to the Typegen import so that ESM build contexts are satisfied.

closes https://github.com/statelyai/xstate-tools/issues/108