### PR TITLE
Fixed an issue with typegen files being sometimes generated by the CLI when they shouldn't be

### DIFF
--- a/.changeset/kind-meals-jog.md
+++ b/.changeset/kind-meals-jog.md
@@ -1,0 +1,5 @@
+---
+'@xstate/cli': patch
+---
+
+Fixed an issue with typegen files being sometimes generated when they shouldn't be.

--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -102,7 +102,11 @@ const writeToFiles = async (uriArray: string[], { cwd }: { cwd: string }) => {
             getTypegenData(path.basename(uri), index, machineResult),
           );
 
-        await writeToTypegenFile(typegenUri, types, { cwd });
+        if (types.length) {
+          await writeToTypegenFile(typegenUri, types, { cwd });
+        } else {
+          await removeFile(typegenUri);
+        }
 
         const edits = getTsTypesEdits(types);
         if (edits.length > 0) {


### PR DESCRIPTION
Essentially the same change as [here](https://github.com/statelyai/xstate-tools/pull/327/files). At that time, `@xstate/cli` didn't require any changes but later I've done some refactors in https://github.com/statelyai/xstate-tools/pull/328 and missed doing this here.

fixes https://github.com/statelyai/xstate-tools/issues/340