### PR TITLE
enable linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,8 @@
-node_modules/**
-apps/extension/client/node_modules/**
-apps/extension/client/out/**
-apps/extension/server/node_modules/**
-apps/extension/server/out/**
+**/dist
+**/out
+**/*.typegen.ts
+
+apps/cli/bin
+apps/extension/client/bundled-editor
+apps/extension/client/scripts
+apps/extension/client/testFixture/machine.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,20 +1,60 @@
-/**@type {import('eslint').Linter.Config} */
-// eslint-disable-next-line no-undef
-module.exports = {
-  // root: true,
-  // parser: '@typescript-eslint/parser',
-  // plugins: [
-  // 	'@typescript-eslint',
-  // ],
-  // extends: [
-  // 	'eslint:recommended',
-  // 	'plugin:@typescript-eslint/recommended',
-  // ],
-  // rules: {
-  // 	'semi': [2, "always"],
-  // 	'@typescript-eslint/no-unused-vars': 0,
-  // 	'@typescript-eslint/no-explicit-any': 0,
-  // 	'@typescript-eslint/explicit-module-boundary-types': 0,
-  // 	'@typescript-eslint/no-non-null-assertion': 0,
-  // }
+/** @type {import('eslint').Linter.Config} */
+const config = {
+  extends: [
+    'eslint:recommended',
+    'plugin:eslint-comments/recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  env: {
+    browser: true,
+    node: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: [
+      './tsconfig.eslint.json',
+      './apps/**/tsconfig.json',
+      './packages/*/tsconfig.json',
+    ],
+  },
+  plugins: ['@typescript-eslint'],
+  root: true,
+  rules: {
+    'eslint-comments/no-unused-disable': 'error',
+  },
+  overrides: [
+    // override for all typescript files
+    {
+      files: ['**/*.{ts,tsx}'],
+      extends: [
+        // enable type-aware linting rules
+        'plugin:@typescript-eslint/recommended-requiring-type-checking',
+      ],
+    },
+    // override for workspace config/script files
+    {
+      files: ['*.js', 'scripts/*.js'],
+      rules: {
+        // disable `require` errors
+        '@typescript-eslint/no-var-requires': 'off',
+      },
+    },
+    // override for test files
+    {
+      files: ['**/__tests__/**/*.{ts,tsx}', '**/*.{spec,test}.{ts,tsx}'],
+      extends: ['plugin:jest/recommended'],
+      plugins: ['jest'],
+      rules: {
+        '@typescript-eslint/no-empty-function': 'off',
+        '@typescript-eslint/no-non-null-assertion': 'off',
+        '@typescript-eslint/no-unsafe-call': 'warn',
+        '@typescript-eslint/no-unsafe-argument': 'warn',
+        '@typescript-eslint/no-unsafe-assignment': 'warn',
+        '@typescript-eslint/no-unsafe-member-access': 'warn',
+      },
+    },
+  ],
 };
+
+module.exports = config;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
 
       - run: yarn
       - run: yarn turbo run lint test
+      - run: yarn lint
       - run: yarn deps:build
       - run: yarn turbo run build
       - run: yarn vscode:dev

--- a/apps/cli/src/__tests__/__examples__/bug-report-1.ts
+++ b/apps/cli/src/__tests__/__examples__/bug-report-1.ts
@@ -1,6 +1,6 @@
 import { assign, createMachine } from 'xstate';
 
-type Data = {};
+type Data = unknown;
 
 type Context = {
   data: Data[];
@@ -73,9 +73,11 @@ const machine = createMachine(
        * This service will now type error if it
        * returns anything other than { id: string }
        */
+      // eslint-disable-next-line @typescript-eslint/require-await
       pollData: async () => {
         return [];
       },
+      // eslint-disable-next-line @typescript-eslint/require-await
       getData: async () => {
         return [];
       },

--- a/apps/cli/src/__tests__/examples.test.ts
+++ b/apps/cli/src/__tests__/examples.test.ts
@@ -18,7 +18,7 @@ describe('typegen', () => {
   execSync('node ../../bin/bin.js typegen "./__examples__/*.ts"', {
     cwd: __dirname,
   });
-  it('Should pass tsc', async () => {
+  it('Should pass tsc', () => {
     try {
       execSync(`tsc`, {
         cwd: examplesPath,

--- a/apps/extension/client/src/checkTypegenNesting.ts
+++ b/apps/extension/client/src/checkTypegenNesting.ts
@@ -45,6 +45,7 @@ const enableTypegenNesting = () => {
   if (!fileNestingPatterns || typeof fileNestingPatterns !== 'object') return;
 
   // If the user chooses to enable file nesting for typegen files we need to make sure that VSCode's file nesting is also enabled
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
   fileNestingConfig.update('enabled', true, true);
 
   const getUpdatedPattern = (typegenPatternKey: string) => {
@@ -63,6 +64,7 @@ const enableTypegenNesting = () => {
   const updatedPatterns = createTypegenPatterns(getUpdatedPattern);
 
   // Update file nesting patterns with all existing patterns and our updated pattern
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
   fileNestingConfig.update(
     'patterns',
     {
@@ -106,6 +108,7 @@ const disableTypegenNesting = () => {
   const updatedPatterns = createTypegenPatterns(getUpdatedPattern);
 
   // Update file nesting patterns with all existing patterns and our updated pattern
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
   fileNestingConfig.update(
     'patterns',
     removeEmptyPatterns({
@@ -158,6 +161,7 @@ export const handleTypegenNestingConfig = () => {
     const enableOption = 'Enable';
     const disableOption = "No, don't ask again";
     const learnMoreOption = 'Learn more';
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     vscode.window
       .showInformationMessage(
         'Do you want to enable file nesting for XState typegen files?',
@@ -171,10 +175,12 @@ export const handleTypegenNestingConfig = () => {
             enableTypegenNesting();
             break;
           case disableOption:
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             getXStateConfig().update('nestTypegenFiles', false, true);
             disableTypegenNesting();
             break;
           case learnMoreOption:
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
             vscode.env.openExternal(
               Uri.parse('https://stately.ai/blog/nesting-xstate-typegen-files'),
             );

--- a/apps/extension/client/src/getWebviewContent.ts
+++ b/apps/extension/client/src/getWebviewContent.ts
@@ -40,7 +40,7 @@ export const getWebviewContent = (scriptsSrc: vscode.Uri, title: string) => {
                   <div class="iframe-wrapper">
                       <iframe id="iframe" title="${title} Iframe"></iframe>
                   </div>
-                  <script src="${scriptsSrc}">
+                  <script src="${scriptsSrc.toString()}">
               </body>
           </html>
       `;

--- a/apps/extension/client/src/initiateTypegen.ts
+++ b/apps/extension/client/src/initiateTypegen.ts
@@ -4,7 +4,7 @@ import { registerDisposable } from './registerDisposable';
 import { TypeSafeLanguageClient } from './typeSafeLanguageClient';
 
 const createDeferred = () => {
-  let deferred: {
+  const deferred: {
     resolve?: () => void;
     reject?: () => void;
     promise?: Promise<void>;
@@ -36,11 +36,13 @@ const createTypegenFile = async (
       if (String(textDocument.uri) === String(typegenUri)) {
         documentOpened.resolve();
         // by saving here we
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         textDocument.save();
       }
     }),
   );
 
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
   Promise.race([
     // timeout shouldn't happen in practice
     // it's not clear how strong guarantees we have for this though
@@ -115,6 +117,7 @@ export const initiateTypegen = (
     context,
     languageClient.onNotification(
       'typesUpdated',
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async ({ typegenUri, types }) => {
         await createTypegenFile(context, typegenUri, types);
       },

--- a/apps/extension/client/src/initiateVisualizer.ts
+++ b/apps/extension/client/src/initiateVisualizer.ts
@@ -14,6 +14,7 @@ export const initiateVisualizer = (
   let lastTokenSource: vscode.CancellationTokenSource | undefined;
 
   const sendMessage = (event: VizWebviewMachineEvent) => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     currentPanel?.webview.postMessage(event);
   };
 
@@ -23,6 +24,7 @@ export const initiateVisualizer = (
     uri: string,
     guardsToMock: string[],
   ) => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     languageClient.sendRequest('setDisplayedMachine', {
       uri,
       machineIndex,
@@ -60,6 +62,7 @@ export const initiateVisualizer = (
       // Handle disposing the current XState Visualizer
       currentPanel.onDidDispose(
         () => {
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           languageClient.sendRequest('clearDisplayedMachine', undefined);
           currentPanel = undefined;
         },
@@ -70,31 +73,38 @@ export const initiateVisualizer = (
   };
 
   context.subscriptions.push(
-    typeSafeVsCode.registerCommand('stately-xstate.visualize', async () => {
-      lastTokenSource?.cancel();
-      lastTokenSource = new vscode.CancellationTokenSource();
-      try {
-        const activeTextEditor = vscode.window.activeTextEditor!;
-        const uri = resolveUriToFilePrefix(activeTextEditor.document.uri.path);
-        const { config, machineIndex, namedGuards } =
-          await languageClient.sendRequest(
-            'getMachineAtCursorPosition',
-            {
-              uri,
-              position: {
-                line: activeTextEditor.selection.start.line,
-                column: activeTextEditor.selection.start.character,
-              },
-            },
-            lastTokenSource.token,
+    typeSafeVsCode.registerCommand(
+      'stately-xstate.visualize',
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      async () => {
+        lastTokenSource?.cancel();
+        lastTokenSource = new vscode.CancellationTokenSource();
+        try {
+          const activeTextEditor = vscode.window.activeTextEditor!;
+          const uri = resolveUriToFilePrefix(
+            activeTextEditor.document.uri.path,
           );
-        startService(config, machineIndex, uri, namedGuards);
-      } catch {
-        vscode.window.showErrorMessage(
-          'Could not find a machine at the current cursor.',
-        );
-      }
-    }),
+          const { config, machineIndex, namedGuards } =
+            await languageClient.sendRequest(
+              'getMachineAtCursorPosition',
+              {
+                uri,
+                position: {
+                  line: activeTextEditor.selection.start.line,
+                  column: activeTextEditor.selection.start.character,
+                },
+              },
+              lastTokenSource.token,
+            );
+          startService(config, machineIndex, uri, namedGuards);
+        } catch {
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+          vscode.window.showErrorMessage(
+            'Could not find a machine at the current cursor.',
+          );
+        }
+      },
+    ),
   );
 
   context.subscriptions.push(
@@ -116,6 +126,7 @@ export const initiateVisualizer = (
       (uri, machineIndex) => {
         lastTokenSource?.cancel();
         lastTokenSource = new vscode.CancellationTokenSource();
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         languageClient
           .sendRequest(
             'getMachineAtIndex',

--- a/apps/extension/client/src/vizWebviewScript.ts
+++ b/apps/extension/client/src/vizWebviewScript.ts
@@ -28,6 +28,7 @@ const machine = createMachine<WebViewMachineContext, VizWebviewMachineEvent>({
     src: () => (send) => {
       window.addEventListener('message', (event) => {
         try {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
           send(event.data);
         } catch (e) {
           console.warn(e);

--- a/apps/extension/server/src/diagnostics/misc.ts
+++ b/apps/extension/server/src/diagnostics/misc.ts
@@ -24,7 +24,7 @@ export const miscDiagnostics: DiagnosticGetter = (
     const machine = createIntrospectableMachine(machineResult);
     machine.transition(machine.initialState, {} as any);
   } catch (e) {
-    let range: Range = {
+    const range: Range = {
       start: textDocument.positionAt(
         machineResult.machineCallResult?.definition?.node.start || 0,
       ),
@@ -91,6 +91,7 @@ export const miscDiagnostics: DiagnosticGetter = (
     // }
     return [
       {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
         message: (e as any).message,
         range,
         severity: DiagnosticSeverity.Error,

--- a/apps/extension/server/src/getCursorHoverType.ts
+++ b/apps/extension/server/src/getCursorHoverType.ts
@@ -200,7 +200,7 @@ const getServiceMatchingCursor = (
   position: Position,
 ) => {
   return parseResult?.getAllServices(['named']).find((service) => {
-    return isCursorInPosition(service.srcNode?.loc!, position);
+    return isCursorInPosition(service.srcNode!.loc!, position);
   });
 };
 

--- a/apps/extension/server/src/getReferences.ts
+++ b/apps/extension/server/src/getReferences.ts
@@ -26,7 +26,8 @@ export const getReferences = (
 
       const state = fullMachine.getStateNodeByPath(cursorHover.state.path);
 
-      // @ts-ignore
+      // @ts-expect-error intentional assignment to private property
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
       const targetStates: { id: string }[] = state.resolveTarget([
         cursorHover.target?.value,
       ]);
@@ -154,7 +155,9 @@ export const getReferences = (
         };
       });
     }
-  } catch (e) {}
+  } catch (e) {
+    //
+  }
 
   return [];
 };

--- a/apps/extension/server/src/typeSafeConnection.ts
+++ b/apps/extension/server/src/typeSafeConnection.ts
@@ -2,10 +2,10 @@ import { NotificationMap, RequestMap } from '@xstate/tools-shared';
 import * as vscode from 'vscode';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import {
-  createConnection,
   HandlerResult,
   ProposedFeatures,
   TextDocuments,
+  createConnection,
 } from 'vscode-languageserver/node';
 
 function _createTypeSafeConnection() {
@@ -35,5 +35,4 @@ function _createTypeSafeConnection() {
 export const createTypeSafeConnection: () => TypeSafeConnection =
   _createTypeSafeConnection;
 
-export interface TypeSafeConnection
-  extends ReturnType<typeof _createTypeSafeConnection> {}
+export type TypeSafeConnection = ReturnType<typeof _createTypeSafeConnection>;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "deps:build": "preconstruct build",
     "vscode:dev": "yarn turbo run vscode:build:dev --no-cache && cp apps/extension/server/dist/index.js apps/extension/client/dist/server.js",
     "vscode:prod": "yarn turbo run vscode:build:prod --no-cache && cp apps/extension/server/dist/index.js apps/extension/client/dist/server.js",
-    "test": "jest"
+    "test": "jest",
+    "lint": "eslint ."
   },
   "preconstruct": {
     "packages": [
@@ -93,11 +94,13 @@
     "@manypkg/cli": "^0.19.1",
     "@preconstruct/cli": "^2.5.0",
     "@types/node": "^16.0.1",
-    "@typescript-eslint/eslint-plugin": "^5.59.0",
-    "@typescript-eslint/parser": "^5.59.0",
+    "@typescript-eslint/eslint-plugin": "^5.59.9",
+    "@typescript-eslint/parser": "^5.59.9",
     "concurrently": "6.2.0",
     "esbuild": "^0.14.48",
-    "eslint": "^7.26.0",
+    "eslint": "^8.42.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-jest": "^27.2.1",
     "husky": "^8.0.1",
     "lint-staged": ">=10",
     "patch-package": "^6.4.7",

--- a/packages/machine-extractor/src/MachineExtractResult.ts
+++ b/packages/machine-extractor/src/MachineExtractResult.ts
@@ -4,12 +4,12 @@ import * as recast from 'recast';
 import { Action, Condition, MachineOptions } from 'xstate';
 import { choose } from 'xstate/lib/actions';
 import { DeclarationType } from '.';
+import { RecordOfArrays } from './RecordOfArrays';
 import { ActionNode, ParsedChooseCondition } from './actions';
 import { getMachineNodesFromFile } from './getMachineNodesFromFile';
 import { TMachineCallExpression } from './machineCallExpression';
-import { RecordOfArrays } from './RecordOfArrays';
 import { StateNodeReturn } from './stateNode';
-import { toMachineConfig, ToMachineConfigOptions } from './toMachineConfig';
+import { ToMachineConfigOptions, toMachineConfig } from './toMachineConfig';
 import { TransitionConfigNode } from './transitions';
 import { Comment } from './types';
 
@@ -747,13 +747,14 @@ export class MachineExtractResult {
     // so there is a risk that modifying multiple machines in a single file would lead to problems
     // however, we never modify multiple machines based on the same file content so this is somewhat safe
     // each modification updates the AST, that is printed and the file is re-parsed, so the next modification sees the next AST
-    const ast: RecastFile = recast.parse(this._fileContent, {
+    this._fileContent;
+    const ast = recast.parse(this._fileContent, {
       parser: {
         // this is a slight hack to defer the work done by `recast.parse`
         // we don't need to re-parse the file though, as we already have the AST
         parse: () => this._fileAst,
       },
-    });
+    }) as RecastFile;
 
     const recastDefinitionNode = findRecastDefinitionNode(
       ast,
@@ -1334,11 +1335,14 @@ export class MachineExtractResult {
 
           if (n.ArrayExpression.check(transitionProp.value)) {
             if (transitionProp.value.elements.length === 1) {
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               transitionProp.value = minifiedTransition as any;
               break;
             }
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             transitionProp.value.elements[index] = minifiedTransition as any;
           } else {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             transitionProp.value = minifiedTransition as any;
           }
           break;
@@ -1390,11 +1394,14 @@ export class MachineExtractResult {
 
           if (n.ArrayExpression.check(transitionProp.value)) {
             if (transitionProp.value.elements.length === 1) {
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               transitionProp.value = minifiedTransition as any;
               break;
             }
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             transitionProp.value.elements[index] = minifiedTransition as any;
           } else {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             transitionProp.value = minifiedTransition as any;
           }
           break;
@@ -1622,13 +1629,13 @@ export class MachineExtractResult {
     // so there is a risk that modifying multiple machines in a single file would lead to problems
     // however, we never modify multiple machines based on the same file content so this is somewhat safe
     // each modification updates the AST, that is printed and the file is re-parsed, so the next modification sees the next AST
-    const ast: RecastFile = recast.parse(this._fileContent, {
+    const ast = recast.parse(this._fileContent, {
       parser: {
         // this is a slight hack to defer the work done by `recast.parse`
         // we don't need to re-parse the file though, as we already have the AST
         parse: () => this._fileAst,
       },
-    });
+    }) as RecastFile;
 
     const recastDefinitionNode = findRecastDefinitionNode(
       ast,
@@ -1722,10 +1729,12 @@ function setProperty(
 ) {
   const prop = findObjectProperty(obj, propName);
   if (prop) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     prop.value = value as any;
     return;
   }
   obj.properties.push(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     b.objectProperty(safePropertyKey(propName), value as any),
   );
 }
@@ -1771,6 +1780,7 @@ function updateInvoke(
 
   if (typeof data.source === 'string') {
     const srcProp = findObjectProperty(invoke, 'src')!;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     srcProp.value = updateItemType(
       unwrapSimplePropValue(srcProp)!,
       b.stringLiteral(data.source),
@@ -1896,7 +1906,7 @@ function getPropByPath(ast: RecastObjectExpression, path: (string | number)[]) {
     );
   }
   const pathCopy = [...path];
-  let segment: typeof path[number] | undefined;
+  let segment: (typeof path)[number] | undefined;
   let current: RecastNode | undefined | null = ast;
   while ((segment = pathCopy.shift()) !== undefined) {
     if (typeof segment === 'string') {
@@ -1936,7 +1946,7 @@ function insertAtTransitionPath(
     );
   }
   const pathCopy = path.slice(0, -1);
-  let segment: typeof path[number] | undefined;
+  let segment: (typeof path)[number] | undefined;
   let current: RecastNode = ast;
 
   while ((segment = pathCopy.shift()) !== undefined) {
@@ -1950,6 +1960,7 @@ function insertAtTransitionPath(
 
       if (!pathCopy.length) {
         current.properties.push(
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
           b.objectProperty(safePropertyKey(segment), value as any),
         );
         return;
@@ -1969,12 +1980,14 @@ function insertAtTransitionPath(
     if (!pathCopy.length) {
       n.ObjectProperty.assert(prop);
       if (!n.ArrayExpression.check(prop.value)) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         prop.value = b.arrayExpression([prop.value as any]);
       }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       prop.value.elements.splice(last(path), 0, value as any);
       return;
     }
-    let unwrapped = unwrapSimplePropValue(prop)!;
+    const unwrapped = unwrapSimplePropValue(prop)!;
     if (typeof pathCopy[0] === 'number') {
       const index = pathCopy.shift() as number;
       if (n.ArrayExpression.check(unwrapped)) {
@@ -1991,7 +2004,7 @@ function getTransitionObject(
   path: TransitionPath,
 ) {
   const pathCopy = [...path];
-  let segment: typeof path[number] | undefined;
+  let segment: (typeof path)[number] | undefined;
   let current: RecastNode = obj;
 
   while ((segment = pathCopy.shift()) !== undefined) {
@@ -2000,7 +2013,7 @@ function getTransitionObject(
         ? findObjectProperty(current as RecastObjectExpression, segment)!
         : findArrayElementWithSingularFallback(current, segment)!;
 
-    let unwrapped = unwrapSimplePropValue(prop)!;
+    const unwrapped = unwrapSimplePropValue(prop)!;
 
     if (typeof pathCopy[0] === 'number') {
       const index = pathCopy.shift() as number;
@@ -2136,6 +2149,7 @@ function insertGuardAtTransitionPath(
 ) {
   const transition = getTransitionObject(obj, path);
   transition.properties.push(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     b.objectProperty(b.identifier('cond'), value as any),
   );
 }
@@ -2153,6 +2167,7 @@ function editGuardAtTransitionPath(
 
   const condProp = transition.properties[condIndex];
   n.ObjectProperty.assert(condProp);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   condProp.value = updateItemType(
     unwrapSimplePropValue(condProp)!,
     value,
@@ -2185,11 +2200,14 @@ function updateTransitionAtPathWith(
     const transitionProp = getPropByPath(obj, path.slice(0, -1))!;
     if (n.ArrayExpression.check(transitionProp.value)) {
       if (transitionProp.value.elements.length === 1) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         transitionProp.value = minified as any;
         return;
       }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       transitionProp.value.elements[last(path)] = minified as any;
     } else {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       transitionProp.value = minified as any;
     }
   }
@@ -2209,6 +2227,7 @@ function insertAtArrayifiableProperty({
   const propIndex = findObjectPropertyIndex(obj, property);
   if (propIndex === -1) {
     obj.properties.push(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       b.objectProperty(safePropertyKey(property), value as any),
     );
     return;
@@ -2217,10 +2236,12 @@ function insertAtArrayifiableProperty({
   if (!n.ArrayExpression.check(unwrapped)) {
     const prop = obj.properties[propIndex];
     n.ObjectProperty.assert(prop);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     prop.value = b.arrayExpression([unwrapped as any]);
   }
   const arr = unwrapSimplePropValue(obj.properties[propIndex]);
   n.ArrayExpression.assert(arr);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   arr.elements.splice(index, 0, value as any);
 }
 
@@ -2271,9 +2292,11 @@ function editAtArrayifiableProperty({
 
   const unwrapped = unwrapSimplePropValue(obj.properties[propIndex])!;
   if (!n.ArrayExpression.check(unwrapped)) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     prop.value = updateItemType(unwrapped, value) as any;
     return;
   }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   unwrapped.elements[index] = updateItemType(
     unwrapped.elements[index]!,
     value,
@@ -2283,6 +2306,7 @@ function editAtArrayifiableProperty({
 function updateItemType(item: RecastNode, newName: RecastNode) {
   if (n.ObjectExpression.check(item)) {
     const prop = findObjectProperty(item, 'type')!;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     prop.value = newName as any;
     return item;
   }
@@ -2292,6 +2316,7 @@ function updateItemType(item: RecastNode, newName: RecastNode) {
 function upgradeSimpleTarget(transition: RecastNode) {
   if (!n.ObjectExpression.check(transition)) {
     return b.objectExpression([
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       b.objectProperty(b.identifier('target'), transition as any),
     ]);
   }
@@ -2405,6 +2430,7 @@ function toObjectExpression(
       if (Array.isArray(value)) {
         throw new Error('Converting arrays is not implemented');
       }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const valueNode = n.Node.check(value)
         ? (value as any)
         : typeof value === 'string'
@@ -2425,6 +2451,7 @@ function toObjectExpression(
           'Converting this type of a value to a node has not been implemented',
         );
       }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       return b.objectProperty(safePropertyKey(key), valueNode);
     }),
   );
@@ -2531,6 +2558,7 @@ function removeTransitionAtPath(
       switch (unwrapped.elements.length) {
         case 0: {
           removeProperty(obj, propPath[0]);
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
           return removed as any;
         }
         case 1: {
@@ -2538,10 +2566,13 @@ function removeTransitionAtPath(
           n.ObjectProperty.assert(prop);
           // array elements should be expressions and property values should be expressions too
           // so this should always be valid in practice
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           prop.value = unwrapped.elements[0] as any;
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
           return removed as any;
         }
         default: {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
           return removed as any;
         }
       }
@@ -2673,7 +2704,7 @@ function getIndexForTransitionPathAppendant(
   // this function is supposed to ignore the last element (the index)
   // we only want check max existing index of this path in the given state object
   const pathCopy = path.slice(0, -1);
-  let segment: typeof path[number] | undefined;
+  let segment: (typeof path)[number] | undefined;
   let current: RecastNode = ast;
 
   while ((segment = pathCopy.shift()) !== undefined) {
@@ -2693,7 +2724,7 @@ function getIndexForTransitionPathAppendant(
       }
       return prop.value.elements.length;
     }
-    let unwrapped = unwrapSimplePropValue(prop)!;
+    const unwrapped = unwrapSimplePropValue(prop)!;
     if (typeof pathCopy[0] === 'number') {
       const index = pathCopy.shift() as number;
       if (n.ArrayExpression.check(unwrapped)) {
@@ -2781,7 +2812,7 @@ function consumeIndentationToNodeAtIndex(
     return '';
   }
   let indentation = '';
-  let i = index;
+  // eslint-disable-next-line no-constant-condition
   while (true) {
     index--;
     const char = fileContent[index];

--- a/packages/machine-extractor/src/__tests__/inline-implementations.test.ts
+++ b/packages/machine-extractor/src/__tests__/inline-implementations.test.ts
@@ -16,7 +16,7 @@ describe('Inline implementations', () => {
 
     const result = extractMachinesFromFile(input)!;
 
-    const machine = result!.machines[0]!;
+    const machine = result.machines[0]!;
 
     const config = machine.toConfig({ hashInlineImplementations: true });
 

--- a/packages/machine-extractor/src/__tests__/modifications/rename_state.test.ts
+++ b/packages/machine-extractor/src/__tests__/modifications/rename_state.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable no-mixed-spaces-and-tabs
 import outdent from 'outdent';
 import { extractMachinesFromFile } from '../../extractMachinesFromFile';
 
@@ -561,6 +562,7 @@ describe('rename_state', () => {
     `);
   });
 
+  // eslint-disable-next-line jest/no-identical-title
   it('should adjust target in the sibling state when renaming a nested state (leading segment)', () => {
     const modifiableMachine = getModifiableMachine(`
       createMachine({
@@ -607,6 +609,7 @@ describe('rename_state', () => {
     `);
   });
 
+  // eslint-disable-next-line jest/no-identical-title
   it('should adjust target in the sibling state when renaming a nested state (segment in the middle)', () => {
     const modifiableMachine = getModifiableMachine(`
       createMachine({

--- a/packages/machine-extractor/src/__tests__/modifications/reparent_state.test.ts
+++ b/packages/machine-extractor/src/__tests__/modifications/reparent_state.test.ts
@@ -452,7 +452,7 @@ describe('reparent_state', () => {
     `);
   });
 
-  it(`should keep the sibling transition target that targets a state within the reparented state `, () => {
+  it(`should keep the sibling transition target that targets a state within the reparented state`, () => {
     const modifiableMachine = getModifiableMachine(`
       createMachine({
         states: {

--- a/packages/machine-extractor/src/__tests__/parseResult.test.ts
+++ b/packages/machine-extractor/src/__tests__/parseResult.test.ts
@@ -140,7 +140,8 @@ describe('MachineParseResult', () => {
         }
       })`,
       'assign({count: ctx => ctx.count + 1})',
-    ].join(',\n');
+    ];
+    /* eslint-disable @typescript-eslint/restrict-template-expressions */
     const config = `
       createMachine({
         initial: 'a',
@@ -163,6 +164,7 @@ describe('MachineParseResult', () => {
         }
       })
     `;
+    /* eslint-enable @typescript-eslint/restrict-template-expressions */
     const result = extractMachinesFromFile(config);
     const machine = result!.machines[0];
 

--- a/packages/machine-extractor/src/__tests__/parseResult.test.ts
+++ b/packages/machine-extractor/src/__tests__/parseResult.test.ts
@@ -140,7 +140,7 @@ describe('MachineParseResult', () => {
         }
       })`,
       'assign({count: ctx => ctx.count + 1})',
-    ];
+    ].join(',\n');
     const config = `
       createMachine({
         initial: 'a',

--- a/packages/machine-extractor/src/__tests__/typeParameters.test.ts
+++ b/packages/machine-extractor/src/__tests__/typeParameters.test.ts
@@ -12,8 +12,8 @@ describe('Type parameter parsing', () => {
     ).toHaveLength(4);
 
     const sliceOfResult = fileText.slice(
-      result.machines[0]!.machineCallResult?.typeArguments?.node.start!,
-      result.machines[0]!.machineCallResult?.typeArguments?.node.end!,
+      result.machines[0]!.machineCallResult.typeArguments!.node.start!,
+      result.machines[0]!.machineCallResult.typeArguments!.node.end!,
     );
 
     expect(sliceOfResult).toEqual('<Context, Event, any, any>');

--- a/packages/machine-extractor/src/actions.ts
+++ b/packages/machine-extractor/src/actions.ts
@@ -66,6 +66,7 @@ export const ActionAsFunctionExpression = maybeTsAsExpression(
     createParser({
       babelMatcher: isFunctionOrArrowFunctionExpression,
       parseNode: (node, context): ActionNode => {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
         const action = function actions() {};
         const id = context.getNodeHash(node);
 
@@ -129,7 +130,7 @@ export const ChooseAction = wrapParserResult(
     const conditions: ParsedChooseCondition[] = [];
 
     result.argument1Result?.forEach((arg1Result) => {
-      const toPush: typeof conditions[number] = {
+      const toPush: (typeof conditions)[number] = {
         condition: {
           actions: [],
         },
@@ -165,6 +166,7 @@ export const ChooseAction = wrapParserResult(
 
 interface AssignFirstArg {
   node: t.Node;
+  // eslint-disable-next-line @typescript-eslint/ban-types
   value: {} | (() => {});
 }
 

--- a/packages/machine-extractor/src/createParser.ts
+++ b/packages/machine-extractor/src/createParser.ts
@@ -13,7 +13,9 @@ export const createParser = <T extends t.Node, Result>(params: {
     return params.babelMatcher(node);
   };
   const parse = (node: any, context: ParserContext): Result | undefined => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     if (!matches(node)) return undefined;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     return params.parseNode(node, context);
   };
   return {

--- a/packages/machine-extractor/src/identifiers.ts
+++ b/packages/machine-extractor/src/identifiers.ts
@@ -19,9 +19,11 @@ export const findVariableDeclaratorWithName = (
 ): t.VariableDeclarator | null | undefined => {
   let declarator: t.VariableDeclarator | null | undefined = null;
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   traverse(file, {
     VariableDeclarator(path) {
       if (t.isIdentifier(path.node.id) && path.node.id.name === name) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         declarator = path.node as any;
       }
     },
@@ -60,9 +62,11 @@ export const findTSEnumDeclarationWithName = (
 ): t.TSEnumDeclaration | null | undefined => {
   let declarator: t.TSEnumDeclaration | null | undefined = null;
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   traverse(file, {
     TSEnumDeclaration(path) {
       if (t.isIdentifier(path.node.id) && path.node.id.name === name) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         declarator = path.node as any;
       }
     },
@@ -99,6 +103,7 @@ const deepMemberExpressionToPath = (
 
 const deepMemberExpression = createParser({
   babelMatcher(node): node is t.MemberExpression | t.Identifier {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     return t.isIdentifier(node) || t.isMemberExpression(node);
   },
   parseNode: (
@@ -129,6 +134,7 @@ export const objectExpressionWithDeepPath = <Result>(
         const pathSection = path[currentIndex];
 
         const objectProperties = getPropertiesOfObjectExpression(
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
           currentNode as any,
           context,
         );
@@ -190,7 +196,7 @@ export const memberExpressionReferencingEnumMember = createParser({
 
     const foundEnum = findTSEnumDeclarationWithName(
       context.file,
-      rootIdentifier?.name!,
+      rootIdentifier!.name,
     );
 
     if (!foundEnum) return undefined;

--- a/packages/machine-extractor/src/toMachineConfig.ts
+++ b/packages/machine-extractor/src/toMachineConfig.ts
@@ -52,6 +52,7 @@ const parseStateNode = (
   }
 
   if (astResult?.type) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     config.type = astResult.type.value as any;
   }
 
@@ -82,6 +83,7 @@ const parseStateNode = (
     config.on = {};
 
     astResult.on.properties.forEach((onProperty) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       (config.on as any)[onProperty.key] = getTransitions(
         onProperty.result,
         opts,
@@ -93,6 +95,7 @@ const parseStateNode = (
     config.after = {};
 
     astResult.after.properties.forEach((afterProperty) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       (config.after as any)[afterProperty.key] = getTransitions(
         afterProperty.result,
         opts,
@@ -147,11 +150,13 @@ const parseStateNode = (
           break;
         case opts?.anonymizeInlineImplementations:
           src = 'anonymous';
+        // eslint-disable-next-line no-fallthrough
         case opts?.hashInlineImplementations:
           src = invoke.src.inlineDeclarationId;
       }
 
-      const toPush: typeof invokes[number] = {
+      const toPush: (typeof invokes)[number] = {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
         src: src || (() => () => {}),
       };
 

--- a/packages/machine-extractor/src/utils.ts
+++ b/packages/machine-extractor/src/utils.ts
@@ -105,6 +105,7 @@ export const staticObjectProperty = <KeyResult>(
     }
   >({
     babelMatcher: (node): node is t.ObjectProperty => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       return t.isObjectProperty(node) && !node.computed;
     },
     parseNode: (node, context) => {
@@ -146,6 +147,7 @@ export const dynamicObjectProperty = <KeyResult>(
     }
   >({
     babelMatcher: (node): node is t.ObjectProperty => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       return t.isObjectProperty(node) && node.computed;
     },
     parseNode: (node, context) => {
@@ -228,7 +230,7 @@ export const getPropertiesOfObjectExpression = (
       const result = propertyKey.parse(property, context);
       if (result && result?.key) {
         propertiesToReturn.push({
-          key: `${result.key?.value}`,
+          key: `${result.key?.value || ''}`,
           node: result.node,
           keyNode: result.key.node,
           property,
@@ -292,14 +294,18 @@ export const objectTypeWithKnownKeys = <
             let result: any | undefined;
 
             if (t.isObjectMethod(property.node)) {
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               result = parser.parse(property.node, context);
             } else if (t.isObjectProperty(property.node)) {
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               result = parser.parse(property.node.value, context);
               if (result) {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                 result._valueNode = property.node.value;
               }
             }
 
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
             (toReturn as any)[key] = result;
           });
 
@@ -412,6 +418,7 @@ export const namedFunctionCall = <Argument1Result, Argument2Result>(
 export const isFunctionOrArrowFunctionExpression = (
   node: any,
 ): node is t.ArrowFunctionExpression | t.FunctionExpression => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   return t.isArrowFunctionExpression(node) || t.isFunctionExpression(node);
 };
 

--- a/packages/machine-extractor/src/wrapParserResult.ts
+++ b/packages/machine-extractor/src/wrapParserResult.ts
@@ -19,6 +19,7 @@ export const wrapParserResult = <T extends t.Node, Result, NewResult>(
     parse: (node: any, context) => {
       const result = parser.parse(node, context);
       if (!result) return undefined;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       return changeResult(result, node, context);
     },
   };

--- a/packages/shared/src/__tests__/getTypegenOutput.test.ts
+++ b/packages/shared/src/__tests__/getTypegenOutput.test.ts
@@ -37,8 +37,10 @@ describe('getTypegenOutput', () => {
 
     if (/\.only$/.test(extensionlessFile)) {
       // preserve original test name
+      // eslint-disable-next-line jest/valid-title, jest/no-focused-tests
       it.only(extensionlessFile.replace(/\.only$/, ''), runTest);
     } else {
+      // eslint-disable-next-line jest/valid-title
       it(extensionlessFile, runTest);
     }
   });

--- a/packages/shared/src/getStateMatchesObjectSyntax.ts
+++ b/packages/shared/src/getStateMatchesObjectSyntax.ts
@@ -17,10 +17,13 @@ export const getStateMatchesObjectSyntax = (
             .map((state) =>
               JSON.stringify(state, (_key, value) => {
                 if (typeof value !== 'object') {
+                  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
                   return value;
                 }
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 return Object.keys(value).reduce<Record<string, any>>(
                   (acc, key) => {
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
                     acc[key] = value[key];
                     return acc;
                   },
@@ -31,6 +34,7 @@ export const getStateMatchesObjectSyntax = (
 
     const substatesWithChildren = Object.entries(subState).filter(
       ([, value]) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         return Object.keys(value).length > 0;
       },
     );
@@ -41,6 +45,7 @@ export const getStateMatchesObjectSyntax = (
           .sort(([stateA], [stateB]) => (stateA < stateB ? -1 : 1))
           .map(([state, value]) => {
             return `${withSafeQuotes(state)}?: ${getUnionForSubState(
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
               value,
               depth + 1,
             )};`;

--- a/packages/shared/src/getTransitionsFromNode.ts
+++ b/packages/shared/src/getTransitionsFromNode.ts
@@ -15,7 +15,7 @@ export const getTransitionsFromNode = (node: StateNode): string[] => {
 
         if ((node.parent?.path.length || 0) > 0) {
           relativeKey = relativeKey.replace(
-            new RegExp(`^${(node.parent as StateNode).path.join('.')}\.`),
+            new RegExp(`^${(node.parent as StateNode).path.join('.')}.`),
             '',
           );
         }
@@ -30,7 +30,7 @@ export const getTransitionsFromNode = (node: StateNode): string[] => {
 
       if ((childNode.parent?.path.length || 0) > 0) {
         relativeKey = relativeKey.replace(
-          new RegExp(`^${(childNode.parent as StateNode).path.join('.')}\.`),
+          new RegExp(`^${(childNode.parent as StateNode).path.join('.')}.`),
           '',
         );
       }
@@ -47,6 +47,7 @@ export const getTransitionsFromNode = (node: StateNode): string[] => {
     .map((id) => rootNode.getStateNodeById(id));
 
   nodesWithId.forEach((idNode) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     getMatchesStates(idNode).forEach((match) => {
       if (idNode.id === rootNode.id) {
         transitions.add(`#${idNode.id}.${match}`);

--- a/packages/shared/src/getTypegenData.ts
+++ b/packages/shared/src/getTypegenData.ts
@@ -3,7 +3,7 @@ import { createIntrospectableMachine } from './createIntrospectableMachine';
 import { IntrospectResult, introspectMachine } from './introspectMachine';
 import { TypegenOptions } from './types';
 
-export interface TypegenData extends ReturnType<typeof getTypegenData> {}
+export type TypegenData = ReturnType<typeof getTypegenData>;
 
 const removeExtension = (fileName: string) => fileName.replace(/\.[^/.]+$/, '');
 
@@ -16,9 +16,10 @@ export const getTypegenData = (
   { useDeclarationFileForTypegenData }: Partial<TypegenOptions> = {},
 ) => {
   const introspectResult = introspectMachine(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     createIntrospectableMachine(machineResult) as any,
   );
-  const tsTypes = machineResult.machineCallResult.definition?.tsTypes?.node!;
+  const tsTypes = machineResult.machineCallResult.definition!.tsTypes!.node;
 
   const providedImplementations = getProvidedImplementations(
     machineResult,

--- a/packages/shared/src/getTypegenOutput.ts
+++ b/packages/shared/src/getTypegenOutput.ts
@@ -90,6 +90,7 @@ export const getTypegenOutput = (types: TypegenData[]) => {
 const toPaths = (stateSchema: StateSchema): string[] => {
   return Object.entries(stateSchema).flatMap(([key, value]) => [
     key,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     ...toPaths(value).map((path) => `${key}.${path}`),
   ]);
 };

--- a/scripts/tag-extension.js
+++ b/scripts/tag-extension.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "types": ["@types/node", "jest"],
+    "noEmit": true,
+    "allowJs": true
+  },
+  "extends": "./tsconfig.json",
+  "include": [".eslintrc.js", "**/*.js", "**/__tests__/**/*.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,13 +10,6 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@babel/code-frame@7.12.11":
-  version "7.12.11"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
-  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
-  dependencies:
-    "@babel/highlight" "^7.10.4"
-
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6", "@babel/code-frame@^7.21.4", "@babel/code-frame@^7.5.5":
   version "7.21.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.21.4.tgz#d0fa9e4413aca81f2b23b9442797bda1826edb39"
@@ -264,7 +257,7 @@
     "@babel/traverse" "^7.21.0"
     "@babel/types" "^7.21.0"
 
-"@babel/highlight@^7.10.4", "@babel/highlight@^7.18.6":
+"@babel/highlight@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz#81158601e93e2563795adcbfbdf5d64be3f2ecdf"
   integrity sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==
@@ -1251,38 +1244,48 @@
     eslint-visitor-keys "^3.3.0"
 
 "@eslint-community/regexpp@^4.4.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.5.0.tgz#f6f729b02feee2c749f57e334b7a1b5f40a81724"
-  integrity sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.5.1.tgz#cdd35dce4fa1a89a4fd42b1599eb35b3af408884"
+  integrity sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==
 
-"@eslint/eslintrc@^0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.2.tgz#f63d0ef06f5c0c57d76c4ab5f63d3835c51b0179"
-  integrity sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==
+"@eslint/eslintrc@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.0.3.tgz#4910db5505f4d503f27774bf356e3704818a0331"
+  integrity sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==
   dependencies:
     ajv "^6.12.4"
-    debug "^4.1.1"
-    espree "^7.3.0"
-    globals "^13.9.0"
-    ignore "^4.0.6"
+    debug "^4.3.2"
+    espree "^9.5.2"
+    globals "^13.19.0"
+    ignore "^5.2.0"
     import-fresh "^3.2.1"
-    js-yaml "^3.13.1"
-    minimatch "^3.0.4"
+    js-yaml "^4.1.0"
+    minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@humanwhocodes/config-array@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
-  integrity sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==
-  dependencies:
-    "@humanwhocodes/object-schema" "^1.2.0"
-    debug "^4.1.1"
-    minimatch "^3.0.4"
+"@eslint/js@8.42.0":
+  version "8.42.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.42.0.tgz#484a1d638de2911e6f5a30c12f49c7e4a3270fb6"
+  integrity sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==
 
-"@humanwhocodes/object-schema@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz#87de7af9c231826fdd68ac7258f77c429e0e5fcf"
-  integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
+"@humanwhocodes/config-array@^0.11.10":
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.10.tgz#5a3ffe32cc9306365fb3fd572596cd602d5e12d2"
+  integrity sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==
+  dependencies:
+    "@humanwhocodes/object-schema" "^1.2.1"
+    debug "^4.1.1"
+    minimatch "^3.0.5"
+
+"@humanwhocodes/module-importer@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz#af5b2691a22b44be847b0ca81641c5fb6ad0172c"
+  integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
+
+"@humanwhocodes/object-schema@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
+  integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -1637,7 +1640,7 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@nodelib/fs.walk@^1.2.3":
+"@nodelib/fs.walk@^1.2.3", "@nodelib/fs.walk@^1.2.8":
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
   integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
@@ -1894,9 +1897,9 @@
     pretty-format "^27.0.0"
 
 "@types/json-schema@^7.0.9":
-  version "7.0.11"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
-  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
+  version "7.0.12"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.12.tgz#d70faba7039d5fca54c83c7dbab41051d2b6f6cb"
+  integrity sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==
 
 "@types/lz-string@^1.3.34":
   version "1.3.34"
@@ -1951,9 +1954,9 @@
   integrity sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==
 
 "@types/semver@^7.3.12":
-  version "7.3.13"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
-  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.0.tgz#591c1ce3a702c45ee15f47a42ade72c2fd78978a"
+  integrity sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==
 
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
@@ -1984,15 +1987,15 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.0.tgz#c0e10eeb936debe5d1c3433cf36206a95befefd0"
-  integrity sha512-p0QgrEyrxAWBecR56gyn3wkG15TJdI//eetInP3zYRewDh0XS+DhB3VUAd3QqvziFsfaQIoIuZMxZRB7vXYaYw==
+"@typescript-eslint/eslint-plugin@^5.59.9":
+  version "5.59.9"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.9.tgz#2604cfaf2b306e120044f901e20c8ed926debf15"
+  integrity sha512-4uQIBq1ffXd2YvF7MAvehWKW3zVv/w+mSfRAu+8cKbfj3nwzyqJLNcZJpQ/WZ1HLbJDiowwmQ6NO+63nCA+fqA==
   dependencies:
     "@eslint-community/regexpp" "^4.4.0"
-    "@typescript-eslint/scope-manager" "5.59.0"
-    "@typescript-eslint/type-utils" "5.59.0"
-    "@typescript-eslint/utils" "5.59.0"
+    "@typescript-eslint/scope-manager" "5.59.9"
+    "@typescript-eslint/type-utils" "5.59.9"
+    "@typescript-eslint/utils" "5.59.9"
     debug "^4.3.4"
     grapheme-splitter "^1.0.4"
     ignore "^5.2.0"
@@ -2000,72 +2003,72 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/parser@^5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.59.0.tgz#0ad7cd019346cc5d150363f64869eca10ca9977c"
-  integrity sha512-qK9TZ70eJtjojSUMrrEwA9ZDQ4N0e/AuoOIgXuNBorXYcBDk397D2r5MIe1B3cok/oCtdNC5j+lUUpVB+Dpb+w==
+"@typescript-eslint/parser@^5.59.9":
+  version "5.59.9"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.59.9.tgz#a85c47ccdd7e285697463da15200f9a8561dd5fa"
+  integrity sha512-FsPkRvBtcLQ/eVK1ivDiNYBjn3TGJdXy2fhXX+rc7czWl4ARwnpArwbihSOHI2Peg9WbtGHrbThfBUkZZGTtvQ==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.59.0"
-    "@typescript-eslint/types" "5.59.0"
-    "@typescript-eslint/typescript-estree" "5.59.0"
+    "@typescript-eslint/scope-manager" "5.59.9"
+    "@typescript-eslint/types" "5.59.9"
+    "@typescript-eslint/typescript-estree" "5.59.9"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.59.0.tgz#86501d7a17885710b6716a23be2e93fc54a4fe8c"
-  integrity sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==
+"@typescript-eslint/scope-manager@5.59.9":
+  version "5.59.9"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.59.9.tgz#eadce1f2733389cdb58c49770192c0f95470d2f4"
+  integrity sha512-8RA+E+w78z1+2dzvK/tGZ2cpGigBZ58VMEHDZtpE1v+LLjzrYGc8mMaTONSxKyEkz3IuXFM0IqYiGHlCsmlZxQ==
   dependencies:
-    "@typescript-eslint/types" "5.59.0"
-    "@typescript-eslint/visitor-keys" "5.59.0"
+    "@typescript-eslint/types" "5.59.9"
+    "@typescript-eslint/visitor-keys" "5.59.9"
 
-"@typescript-eslint/type-utils@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.59.0.tgz#8e8d1420fc2265989fa3a0d897bde37f3851e8c9"
-  integrity sha512-d/B6VSWnZwu70kcKQSCqjcXpVH+7ABKH8P1KNn4K7j5PXXuycZTPXF44Nui0TEm6rbWGi8kc78xRgOC4n7xFgA==
+"@typescript-eslint/type-utils@5.59.9":
+  version "5.59.9"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.59.9.tgz#53bfaae2e901e6ac637ab0536d1754dfef4dafc2"
+  integrity sha512-ksEsT0/mEHg9e3qZu98AlSrONAQtrSTljL3ow9CGej8eRo7pe+yaC/mvTjptp23Xo/xIf2mLZKC6KPv4Sji26Q==
   dependencies:
-    "@typescript-eslint/typescript-estree" "5.59.0"
-    "@typescript-eslint/utils" "5.59.0"
+    "@typescript-eslint/typescript-estree" "5.59.9"
+    "@typescript-eslint/utils" "5.59.9"
     debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.0.tgz#3fcdac7dbf923ec5251545acdd9f1d42d7c4fe32"
-  integrity sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA==
+"@typescript-eslint/types@5.59.9":
+  version "5.59.9"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.9.tgz#3b4e7ae63718ce1b966e0ae620adc4099a6dcc52"
+  integrity sha512-uW8H5NRgTVneSVTfiCVffBb8AbwWSKg7qcA4Ot3JI3MPCJGsB4Db4BhvAODIIYE5mNj7Q+VJkK7JxmRhk2Lyjw==
 
-"@typescript-eslint/typescript-estree@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.0.tgz#8869156ee1dcfc5a95be3ed0e2809969ea28e965"
-  integrity sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==
+"@typescript-eslint/typescript-estree@5.59.9":
+  version "5.59.9"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.9.tgz#6bfea844e468427b5e72034d33c9fffc9557392b"
+  integrity sha512-pmM0/VQ7kUhd1QyIxgS+aRvMgw+ZljB3eDb+jYyp6d2bC0mQWLzUDF+DLwCTkQ3tlNyVsvZRXjFyV0LkU/aXjA==
   dependencies:
-    "@typescript-eslint/types" "5.59.0"
-    "@typescript-eslint/visitor-keys" "5.59.0"
+    "@typescript-eslint/types" "5.59.9"
+    "@typescript-eslint/visitor-keys" "5.59.9"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.59.0.tgz#063d066b3bc4850c18872649ed0da9ee72d833d5"
-  integrity sha512-GGLFd+86drlHSvPgN/el6dRQNYYGOvRSDVydsUaQluwIW3HvbXuxyuD5JETvBt/9qGYe+lOrDk6gRrWOHb/FvA==
+"@typescript-eslint/utils@5.59.9", "@typescript-eslint/utils@^5.10.0":
+  version "5.59.9"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.59.9.tgz#adee890107b5ffe02cd46fdaa6c2125fb3c6c7c4"
+  integrity sha512-1PuMYsju/38I5Ggblaeb98TOoUvjhRvLpLa1DoTOFaLWqaXl/1iQ1eGurTXgBY58NUdtfTXKP5xBq7q9NDaLKg==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@types/json-schema" "^7.0.9"
     "@types/semver" "^7.3.12"
-    "@typescript-eslint/scope-manager" "5.59.0"
-    "@typescript-eslint/types" "5.59.0"
-    "@typescript-eslint/typescript-estree" "5.59.0"
+    "@typescript-eslint/scope-manager" "5.59.9"
+    "@typescript-eslint/types" "5.59.9"
+    "@typescript-eslint/typescript-estree" "5.59.9"
     eslint-scope "^5.1.1"
     semver "^7.3.7"
 
-"@typescript-eslint/visitor-keys@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.0.tgz#a59913f2bf0baeb61b5cfcb6135d3926c3854365"
-  integrity sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==
+"@typescript-eslint/visitor-keys@5.59.9":
+  version "5.59.9"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.9.tgz#9f86ef8e95aca30fb5a705bb7430f95fc58b146d"
+  integrity sha512-bT7s0td97KMaLwpEBckbzj/YohnvXtqbe2XgqNvTl6RJVakY5mvENOTPvw5u66nljfZxthESpDozs86U+oLY8Q==
   dependencies:
-    "@typescript-eslint/types" "5.59.0"
+    "@typescript-eslint/types" "5.59.9"
     eslint-visitor-keys "^3.3.0"
 
 "@xstate/inspect@^0.4.1":
@@ -2093,7 +2096,7 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
-acorn-jsx@^5.3.1:
+acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
@@ -2103,7 +2106,7 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn@^7.1.1, acorn@^7.4.0:
+acorn@^7.1.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
@@ -2113,7 +2116,7 @@ acorn@^8.2.4:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
-acorn@^8.5.0:
+acorn@^8.5.0, acorn@^8.8.0:
   version "8.8.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
@@ -2141,16 +2144,6 @@ ajv@^6.10.0, ajv@^6.12.4:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
-ajv@^8.0.1:
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.2.tgz#2fb45e0e5fcbc0813326c1c3da535d1881bb0571"
-  integrity sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 ansi-colors@^4.1.1:
@@ -2226,6 +2219,11 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -3001,7 +2999,7 @@ date-fns@^2.16.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
   integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@4, debug@^4.1.0, debug@^4.1.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -3015,17 +3013,17 @@ debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
+debug@^4.3.2, debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 debug@^4.3.3:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
-  dependencies:
-    ms "2.1.2"
-
-debug@^4.3.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
@@ -3069,12 +3067,7 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
-deep-is@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
-  integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
-
-deep-is@~0.1.3:
+deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
@@ -3223,7 +3216,7 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enquirer@^2.3.0, enquirer@^2.3.5, enquirer@^2.3.6:
+enquirer@^2.3.0, enquirer@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
@@ -3409,6 +3402,21 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-plugin-eslint-comments@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz#9e1cd7b4413526abb313933071d7aba05ca12ffa"
+  integrity sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    ignore "^5.0.5"
+
+eslint-plugin-jest@^27.2.1:
+  version "27.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-27.2.1.tgz#b85b4adf41c682ea29f1f01c8b11ccc39b5c672c"
+  integrity sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==
+  dependencies:
+    "@typescript-eslint/utils" "^5.10.0"
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -3417,92 +3425,82 @@ eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-utils@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
-  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
+eslint-scope@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.0.tgz#f21ebdafda02352f103634b96dd47d9f81ca117b"
+  integrity sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==
   dependencies:
-    eslint-visitor-keys "^1.1.0"
+    esrecurse "^4.3.0"
+    estraverse "^5.2.0"
 
-eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
-  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
+eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz#c22c48f48942d08ca824cc526211ae400478a994"
+  integrity sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==
 
-eslint-visitor-keys@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
-  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
-
-eslint-visitor-keys@^3.3.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz#c7f0f956124ce677047ddbc192a68f999454dedc"
-  integrity sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==
-
-eslint@^7.26.0:
-  version "7.30.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.30.0.tgz#6d34ab51aaa56112fd97166226c9a97f505474f8"
-  integrity sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==
+eslint@^8.42.0:
+  version "8.42.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.42.0.tgz#7bebdc3a55f9ed7167251fe7259f75219cade291"
+  integrity sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==
   dependencies:
-    "@babel/code-frame" "7.12.11"
-    "@eslint/eslintrc" "^0.4.2"
-    "@humanwhocodes/config-array" "^0.5.0"
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@eslint-community/regexpp" "^4.4.0"
+    "@eslint/eslintrc" "^2.0.3"
+    "@eslint/js" "8.42.0"
+    "@humanwhocodes/config-array" "^0.11.10"
+    "@humanwhocodes/module-importer" "^1.0.1"
+    "@nodelib/fs.walk" "^1.2.8"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
-    debug "^4.0.1"
+    debug "^4.3.2"
     doctrine "^3.0.0"
-    enquirer "^2.3.5"
     escape-string-regexp "^4.0.0"
-    eslint-scope "^5.1.1"
-    eslint-utils "^2.1.0"
-    eslint-visitor-keys "^2.0.0"
-    espree "^7.3.1"
-    esquery "^1.4.0"
+    eslint-scope "^7.2.0"
+    eslint-visitor-keys "^3.4.1"
+    espree "^9.5.2"
+    esquery "^1.4.2"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
     file-entry-cache "^6.0.1"
-    functional-red-black-tree "^1.0.1"
-    glob-parent "^5.1.2"
-    globals "^13.6.0"
-    ignore "^4.0.6"
+    find-up "^5.0.0"
+    glob-parent "^6.0.2"
+    globals "^13.19.0"
+    graphemer "^1.4.0"
+    ignore "^5.2.0"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     is-glob "^4.0.0"
-    js-yaml "^3.13.1"
+    is-path-inside "^3.0.3"
+    js-yaml "^4.1.0"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
     lodash.merge "^4.6.2"
-    minimatch "^3.0.4"
+    minimatch "^3.1.2"
     natural-compare "^1.4.0"
     optionator "^0.9.1"
-    progress "^2.0.0"
-    regexpp "^3.1.0"
-    semver "^7.2.1"
-    strip-ansi "^6.0.0"
+    strip-ansi "^6.0.1"
     strip-json-comments "^3.1.0"
-    table "^6.0.9"
     text-table "^0.2.0"
-    v8-compile-cache "^2.0.3"
 
-espree@^7.3.0, espree@^7.3.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
-  integrity sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==
+espree@^9.5.2:
+  version "9.5.2"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.5.2.tgz#e994e7dc33a082a7a82dceaf12883a829353215b"
+  integrity sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==
   dependencies:
-    acorn "^7.4.0"
-    acorn-jsx "^5.3.1"
-    eslint-visitor-keys "^1.3.0"
+    acorn "^8.8.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^3.4.1"
 
 esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
-  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
+esquery@^1.4.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.5.0.tgz#6ce17738de8577694edd7361c57182ac8cb0db0b"
+  integrity sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==
   dependencies:
     estraverse "^5.1.0"
 
@@ -3518,7 +3516,12 @@ estraverse@^4.1.1:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.1.0, estraverse@^5.2.0:
+estraverse@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
+  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
+
+estraverse@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
@@ -3779,9 +3782,9 @@ flat-cache@^3.0.4:
     rimraf "^3.0.2"
 
 flatted@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.1.tgz#bbef080d95fca6709362c73044a1634f7c6e7d05"
-  integrity sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
+  integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
 for-each@^0.3.3:
   version "0.3.3"
@@ -3863,11 +3866,6 @@ function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
-
-functional-red-black-tree@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
-  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -3957,6 +3955,13 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
+glob-parent@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
+  dependencies:
+    is-glob "^4.0.3"
+
 glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
@@ -3991,10 +3996,10 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-globals@^13.6.0, globals@^13.9.0:
-  version "13.10.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.10.0.tgz#60ba56c3ac2ca845cfbf4faeca727ad9dd204676"
-  integrity sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==
+globals@^13.19.0:
+  version "13.20.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.20.0.tgz#ea276a1e508ffd4f1612888f9d1bad1e2717bf82"
+  integrity sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==
   dependencies:
     type-fest "^0.20.2"
 
@@ -4062,6 +4067,11 @@ grapheme-splitter@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
+
+graphemer@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
+  integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
 hard-rejection@^2.1.0:
   version "2.1.0"
@@ -4203,10 +4213,15 @@ ignore-walk@^3.0.3:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^4.0.3, ignore@^4.0.6:
+ignore@^4.0.3:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.0.5:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
+  integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
 ignore@^5.2.0:
   version "5.2.0"
@@ -4474,6 +4489,11 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-path-inside@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 is-plain-obj@^1.1.0:
   version "1.1.0"
@@ -5101,6 +5121,13 @@ js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.6.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
 jsdom@^16.6.0:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.7.0.tgz#918ae71965424b197c819f8183a754e18977b710"
@@ -5159,15 +5186,10 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
-json-schema-traverse@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
-  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
-
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
-  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+  integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
 json5@^2.2.2:
   version "2.2.3"
@@ -5326,11 +5348,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.clonedeep@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
-
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -5345,11 +5362,6 @@ lodash.startcase@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.startcase/-/lodash.startcase-4.4.0.tgz#9436e34ed26093ed7ffae1936144350915d9add8"
   integrity sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg=
-
-lodash.truncate@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
-  integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
 lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
@@ -5555,6 +5567,13 @@ minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@^3.0.5, minimatch@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -6104,11 +6123,6 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-progress@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
-  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
-
 prompts@^2.0.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
@@ -6135,7 +6149,12 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-punycode@^2.1.0, punycode@^2.1.1:
+punycode@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
+  integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
+
+punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
@@ -6270,11 +6289,6 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexpp@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
-  integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
-
 regexpu-core@^5.3.1:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-5.3.2.tgz#11a2b06884f3527aec3e93dbbf4a3b958a95546b"
@@ -6327,11 +6341,6 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
-
-require-from-string@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
-  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 require-main-filename@^2.0.0:
   version "2.0.0"
@@ -6534,7 +6543,7 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
+semver@^7.3.2, semver@^7.3.4:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -6542,9 +6551,9 @@ semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
     lru-cache "^6.0.0"
 
 semver@^7.3.7:
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.0.tgz#ed8c5dc8efb6c629c88b23d41dc9bf40c1d96cd0"
-  integrity sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.1.tgz#c90c4d631cf74720e46b21c1d37ea07edfab91ec"
+  integrity sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -6862,6 +6871,13 @@ strip-ansi@^6.0.0:
   dependencies:
     ansi-regex "^5.0.0"
 
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-ansi@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.0.1.tgz#61740a08ce36b61e50e65653f07060d000975fb2"
@@ -6950,18 +6966,6 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-table@^6.0.9:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/table/-/table-6.7.1.tgz#ee05592b7143831a8c94f3cee6aae4c1ccef33e2"
-  integrity sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==
-  dependencies:
-    ajv "^8.0.1"
-    lodash.clonedeep "^4.5.0"
-    lodash.truncate "^4.4.2"
-    slice-ansi "^4.0.0"
-    string-width "^4.2.0"
-    strip-ansi "^6.0.0"
-
 term-size@^2.1.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.1.tgz#2a6a54840432c2fb6320fea0f415531e90189f54"
@@ -6997,7 +7001,7 @@ test-exclude@^6.0.0:
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
-  integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+  integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
 throat@^6.0.1:
   version "6.0.1"
@@ -7382,7 +7386,7 @@ util@^0.12.0:
     is-typed-array "^1.1.3"
     which-typed-array "^1.1.2"
 
-v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.1:
+v8-compile-cache@^2.1.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==


### PR DESCRIPTION
This PR upgrades and configures `eslint` for the repo, resolves lint errors in packages files, and adds a `lint` step to the `ci` actions workflow.

I made this PR for two reasons:

1. To help encourage healthier practices moving forward
2. To draw attention to how unsafe some of the most critical code in the project is (like `packages/machine-extractor/src/MachineExtractResult.ts`)