### PR TITLE
Fixed an issue with custom action ignoring

### DIFF
--- a/.changeset/rotten-suns-listen.md
+++ b/.changeset/rotten-suns-listen.md
@@ -1,0 +1,6 @@
+---
+'@xstate/tools-shared': patch
+'@xstate/cli': patch
+---
+
+Fixed an issue that could accidentally recognize `"undefined"` as a valid action type.

--- a/packages/shared/src/__tests__/__examples__/entry-actions-named-mixed-with-inline.ts
+++ b/packages/shared/src/__tests__/__examples__/entry-actions-named-mixed-with-inline.ts
@@ -1,0 +1,9 @@
+import { createMachine } from 'xstate';
+
+createMachine({
+  tsTypes:
+    {} as import('./entry-actions-named-mixed-with-inline.typegen').Typegen0,
+  // this test case is using 3 actions on purpose
+  // see https://github.com/statelyai/xstate-tools/pull/389
+  entry: [function action1() {}, function action2() {}, 'action3'],
+});

--- a/packages/shared/src/__tests__/__snapshots__/getTypegenOutput.test.ts.snap
+++ b/packages/shared/src/__tests__/__snapshots__/getTypegenOutput.test.ts.snap
@@ -461,6 +461,33 @@ export interface Typegen0 {
 "
 `;
 
+exports[`getTypegenOutput entry-actions-named-mixed-with-inline 1`] = `
+"// This file was automatically generated. Edits will be overwritten
+
+export interface Typegen0 {
+  "@@xstate/typegen": true;
+  internalEvents: {
+    "xstate.init": { type: "xstate.init" };
+  };
+  invokeSrcNameMap: {};
+  missingImplementations: {
+    actions: "action3";
+    delays: never;
+    guards: never;
+    services: never;
+  };
+  eventsCausingActions: {
+    action3: "xstate.init";
+  };
+  eventsCausingDelays: {};
+  eventsCausingGuards: {};
+  eventsCausingServices: {};
+  matchesStates: undefined;
+  tags: never;
+}
+"
+`;
+
 exports[`getTypegenOutput entry-actions-receive-init-event 1`] = `
 "// This file was automatically generated. Edits will be overwritten
 

--- a/packages/shared/src/forEachAction.ts
+++ b/packages/shared/src/forEachAction.ts
@@ -86,7 +86,7 @@ const replaceOrDeleteActions = <T>(
 ) => {
   const entity = host[prop] as MaybeArray<ExtractorMachineAction>;
   if (Array.isArray(entity)) {
-    for (let i = 0; i < entity.length; i++) {
+    for (let i = entity.length - 1; i >= 0; i--) {
       const val = visitor(entity[i]);
       if (val) {
         entity[i] = val;


### PR DESCRIPTION
I spotted this while working on https://github.com/statelyai/xstate-tools/pull/388 . Splicing within a for loop that moves `i` forward is very dangerous because we shift the items on which the loop didn't yet have a chance to work on.

TODO:

- [x] add a test case