### PR TITLE
Fix problem with Prettier version conflicts for Sky configs

### DIFF
--- a/.changeset/ninety-boats-grab.md
+++ b/.changeset/ninety-boats-grab.md
@@ -1,0 +1,5 @@
+---
+'@xstate/cli': patch
+---
+
+Fix problem with Prettier version conflicts for Sky configs.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -26,7 +26,7 @@
     "commander": "^8.0.0",
     "dotenv": "^16.0.3",
     "isomorphic-fetch": "^3.0.0",
-    "prettier": "^2.8.7",
+    "prettier": "^2.8.8",
     "xstate": "^4.33.4",
     "xstate-beta": "npm:xstate@beta"
   },

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -8,7 +8,7 @@
     "prepare": "yarn build",
     "lint": "tsc",
     "test": "jest",
-    "build": "esbuild src/bin.ts --outdir=bin --platform=node --format=cjs --bundle --loader:.node=file"
+    "build": "esbuild src/bin.ts src/utils.ts src/sky/urlUtils.ts src/sky/writeConfigToFiles.ts src/typegen/writeToFiles.ts --outdir=bin --platform=node --format=cjs --loader:.node=file"
   },
   "devDependencies": {
     "@statelyai/sky": "0.0.4",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -8,7 +8,7 @@
     "prepare": "yarn build",
     "lint": "tsc",
     "test": "jest",
-    "build": "esbuild src/bin.ts src/utils.ts src/sky/urlUtils.ts src/sky/writeConfigToFiles.ts src/typegen/writeToFiles.ts --outdir=bin --platform=node --format=cjs --loader:.node=file"
+    "build": "esbuild src/bin.ts --outdir=bin --platform=node --format=cjs --bundle --loader:.node=file"
   },
   "devDependencies": {
     "@statelyai/sky": "0.0.4",

--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -57,7 +57,7 @@ program
   )
   .argument('<files>', 'The files to target, expressed as a glob pattern')
   .option('-w, --watch', 'Run sky in watch mode')
-  .option('-f, --force', 'Always overwrite existing sky configs')
+  .option('-r, --refetch', 'Always refetch and overwrite existing sky configs')
   .option(
     '-k, --api-key <key>',
     'API key to use for interacting with the Stately Studio',
@@ -66,7 +66,7 @@ program
     async (
       filesPattern: string,
       opts: {
-        force?: boolean;
+        refetch?: boolean;
         watch?: boolean;
         apiKey?: string;
         host?: string;
@@ -80,7 +80,7 @@ program
           writeConfigToFiles({
             uri,
             apiKey,
-            forceFetch: opts.force === true,
+            forceFetch: opts.refetch === true,
             writeToFiles,
             cwd,
           }).catch((e) => {
@@ -98,7 +98,7 @@ program
               writeConfigToFiles({
                 uri,
                 apiKey,
-                forceFetch: opts.force === true,
+                forceFetch: opts.refetch === true,
                 writeToFiles,
                 cwd,
               }),

--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -57,6 +57,7 @@ program
   )
   .argument('<files>', 'The files to target, expressed as a glob pattern')
   .option('-w, --watch', 'Run sky in watch mode')
+  .option('-f, --force', 'Always overwrite existing sky configs')
   .option(
     '-k, --api-key <key>',
     'API key to use for interacting with the Stately Studio',
@@ -64,14 +65,25 @@ program
   .action(
     async (
       filesPattern: string,
-      opts: { watch?: boolean; apiKey?: string; host?: string },
+      opts: {
+        force?: boolean;
+        watch?: boolean;
+        apiKey?: string;
+        host?: string;
+      },
     ) => {
+      const cwd = process.cwd();
       const envApiKey = process.env.SKY_API_KEY;
       const apiKey = opts.apiKey ?? envApiKey;
-
       if (opts.watch) {
         const processFile = (uri: string) => {
-          writeConfigToFiles({ uri, apiKey, writeToFiles }).catch((e) => {
+          writeConfigToFiles({
+            uri,
+            apiKey,
+            forceFetch: opts.force === true,
+            writeToFiles,
+            cwd,
+          }).catch((e) => {
             console.error(e);
           });
         };
@@ -82,7 +94,15 @@ program
         const tasks: Array<Promise<void>> = [];
         watch(filesPattern, { persistent: false })
           .on('add', (uri) => {
-            tasks.push(writeConfigToFiles({ uri, apiKey, writeToFiles }));
+            tasks.push(
+              writeConfigToFiles({
+                uri,
+                apiKey,
+                forceFetch: opts.force === true,
+                writeToFiles,
+                cwd,
+              }),
+            );
           })
           .on('ready', async () => {
             const settled = await allSettled(tasks);

--- a/apps/cli/src/sky/writeConfigToFiles.ts
+++ b/apps/cli/src/sky/writeConfigToFiles.ts
@@ -66,10 +66,11 @@ export const writeConfigToFiles = async (opts: {
               filePath: opts.uri,
             });
             if (code) {
-              const formattedCode = await getPrettierInstance(opts.cwd).format(
-                code,
-                { parser: 'typescript' },
-              );
+              const prettierInstance = getPrettierInstance(opts.cwd);
+              const formattedCode = await prettierInstance.format(code, {
+                ...(await prettierInstance.resolveConfig(opts.uri)),
+                parser: 'typescript',
+              });
               await fs.writeFile(opts.uri, formattedCode);
               console.log(`${opts.uri} - updated with sky config`);
             }

--- a/apps/cli/src/typegen/writeToFiles.ts
+++ b/apps/cli/src/typegen/writeToFiles.ts
@@ -9,6 +9,7 @@ import {
 import 'dotenv/config';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { getPrettierInstance } from '../utils';
 
 async function removeFile(filePath: string) {
   try {
@@ -18,23 +19,6 @@ async function removeFile(filePath: string) {
       return;
     }
     throw e;
-  }
-}
-
-let prettier: typeof import('prettier') | undefined;
-
-function getPrettierInstance(cwd: string): typeof import('prettier') {
-  if (prettier) {
-    return prettier;
-  }
-  try {
-    return require(require.resolve('prettier', { paths: [cwd] }));
-  } catch (err) {
-    if (!err || (err as any).code !== 'MODULE_NOT_FOUND') {
-      throw err;
-    }
-    // we load our own prettier instance lazily on purpose to speed up the init time
-    return (prettier = require('prettier'));
   }
 }
 

--- a/apps/cli/src/utils.ts
+++ b/apps/cli/src/utils.ts
@@ -8,3 +8,19 @@ const allSettled: typeof Promise.allSettled = (promises: Promise<any>[]) =>
       ),
     ),
   );
+
+let prettier: typeof import('prettier') | undefined;
+export function getPrettierInstance(cwd: string): typeof import('prettier') {
+  if (prettier) {
+    return prettier;
+  }
+  try {
+    return require(require.resolve('prettier', { paths: [cwd] }));
+  } catch (err) {
+    if (!err || (err as any).code !== 'MODULE_NOT_FOUND') {
+      throw err;
+    }
+    // we load our own prettier instance lazily on purpose to speed up the init time
+    return (prettier = require('prettier'));
+  }
+}

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "husky": "^8.0.1",
     "lint-staged": ">=10",
     "patch-package": "^6.4.7",
-    "prettier": "^2.8.7",
+    "prettier": "^2.8.8",
     "turbo": "^1.1.2",
     "typescript": "^5.0.4"
   }

--- a/packages/machine-extractor/package.json
+++ b/packages/machine-extractor/package.json
@@ -12,7 +12,6 @@
     "@babel/parser": "^7.21.4",
     "@babel/traverse": "^7.21.4",
     "@babel/types": "^7.21.4",
-    "prettier": "^2.8.8",
     "recast": "^0.23.1"
   },
   "peerDependencies": {

--- a/packages/machine-extractor/package.json
+++ b/packages/machine-extractor/package.json
@@ -12,7 +12,7 @@
     "@babel/parser": "^7.21.4",
     "@babel/traverse": "^7.21.4",
     "@babel/types": "^7.21.4",
-    "prettier": "^2.8.7",
+    "prettier": "^2.8.8",
     "recast": "^0.23.1"
   },
   "peerDependencies": {

--- a/packages/machine-extractor/src/sky/skyConfigModifySource.ts
+++ b/packages/machine-extractor/src/sky/skyConfigModifySource.ts
@@ -45,26 +45,27 @@ export const modifySkyConfigSource = async (opts: {
 
     // Add the import at the top of the file
     ast.program.body.unshift(importDeclaration);
-
-    recast.visit(ast, {
-      visitCallExpression(path) {
-        const node = path.node;
-        if (
-          node.callee.type === 'Identifier' &&
-          ALLOWED_SKY_CONFIG_CALL_EXPRESSION_NAMES.includes(node.callee.name)
-        ) {
-          const args = node.arguments;
-          const hasSkyConfig = args.some((arg) => {
-            return arg.type === 'Identifier' && arg.name === importIdentifier;
-          });
-          if (!hasSkyConfig) {
-            args.push(b.identifier(importIdentifier));
-          }
-        }
-        return false;
-      },
-    });
-
-    return recast.print(ast).code;
   }
+
+  // Add the skyConfig argument to the @statelyai/sky calls if it's not already present
+  recast.visit(ast, {
+    visitCallExpression(path) {
+      const node = path.node;
+      if (
+        node.callee.type === 'Identifier' &&
+        ALLOWED_SKY_CONFIG_CALL_EXPRESSION_NAMES.includes(node.callee.name)
+      ) {
+        const args = node.arguments;
+        const hasSkyConfig = args.some((arg) => {
+          return arg.type === 'Identifier' && arg.name === importIdentifier;
+        });
+        if (!hasSkyConfig) {
+          args.push(b.identifier(importIdentifier));
+        }
+      }
+      return false;
+    },
+  });
+
+  return recast.print(ast).code;
 };

--- a/packages/machine-extractor/src/sky/skyConfigModifySource.ts
+++ b/packages/machine-extractor/src/sky/skyConfigModifySource.ts
@@ -1,13 +1,13 @@
-import * as fs from 'fs/promises';
 import * as path from 'path';
-import * as prettier from 'prettier';
 import * as recast from 'recast';
 import * as babelTs from 'recast/parsers/babel-ts';
 import { ALLOWED_SKY_CONFIG_CALL_EXPRESSION_NAMES } from './skyConfigUtils';
 
-export const modifySkyConfigSource = async (opts: { filePath: string }) => {
-  const fileContents = await fs.readFile(opts.filePath, 'utf8');
-  const ast = recast.parse(fileContents, {
+export const modifySkyConfigSource = async (opts: {
+  fileContents: string;
+  filePath: string;
+}) => {
+  const ast = recast.parse(opts.fileContents, {
     parser: babelTs,
   });
   const b = recast.types.builders;
@@ -65,10 +65,6 @@ export const modifySkyConfigSource = async (opts: { filePath: string }) => {
       },
     });
 
-    const output = recast.print(ast).code;
-    await fs.writeFile(
-      opts.filePath,
-      prettier.format(output, { parser: 'typescript' }),
-    );
+    return recast.print(ast).code;
   }
 };

--- a/packages/machine-extractor/src/sky/skyConfigModifySource.ts
+++ b/packages/machine-extractor/src/sky/skyConfigModifySource.ts
@@ -66,9 +66,14 @@ export const modifySkyConfigSource = async (opts: { filePath: string }) => {
     });
 
     const output = recast.print(ast).code;
+    const prettierConfig = await prettier.resolveConfig(opts.filePath);
+
     await fs.writeFile(
       opts.filePath,
-      prettier.format(output, { parser: 'typescript' }),
+      prettier.format(output, {
+        ...prettierConfig,
+        parser: 'typescript',
+      }),
     );
   }
 };

--- a/packages/machine-extractor/src/sky/skyConfigModifySource.ts
+++ b/packages/machine-extractor/src/sky/skyConfigModifySource.ts
@@ -66,14 +66,9 @@ export const modifySkyConfigSource = async (opts: { filePath: string }) => {
     });
 
     const output = recast.print(ast).code;
-    const prettierConfig = await prettier.resolveConfig(opts.filePath);
-
     await fs.writeFile(
       opts.filePath,
-      prettier.format(output, {
-        ...prettierConfig,
-        parser: 'typescript',
-      }),
+      prettier.format(output, { parser: 'typescript' }),
     );
   }
 };

--- a/packages/machine-extractor/src/sky/skyConfigModifySource.ts
+++ b/packages/machine-extractor/src/sky/skyConfigModifySource.ts
@@ -66,13 +66,9 @@ export const modifySkyConfigSource = async (opts: { filePath: string }) => {
     });
 
     const output = recast.print(ast).code;
-    const prettierConfig = await prettier.resolveConfig(opts.filePath);
     await fs.writeFile(
       opts.filePath,
-      prettier.format(output, {
-        ...prettierConfig,
-        parser: 'typescript',
-      }),
+      prettier.format(output, { parser: 'typescript' }),
     );
   }
 };

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,7 +20,7 @@
     "esbuild-jest": "^0.5.0",
     "jest": "^27.4.7",
     "jest-watch-typeahead": "^1.0.0",
-    "prettier": "^2.8.7",
+    "prettier": "^2.8.8",
     "typescript": "^5.0.4",
     "xstate": "^4.33.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6125,10 +6125,10 @@ prettier@^1.19.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
-prettier@^2.8.7:
-  version "2.8.7"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.7.tgz#bb79fc8729308549d28fe3a98fce73d2c0656450"
-  integrity sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==
+prettier@^2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-format@^27.0.0, pretty-format@^27.4.6:
   version "27.4.6"


### PR DESCRIPTION
This PR fixes two problems with writing Sky configs:

- It fixes a potential version conflict between Prettier 2 & 3 by not using the prettier config of the user for Sky configs.
- It fixes [an unknown type: "ChainExpression" error](https://github.com/prettier/prettier/issues/15489) by upgrading to Prettier 2.8.8