### PR TITLE
Fix getting env variables from import.meta.env.SOME_KEY

### DIFF
--- a/.changeset/nervous-vans-appear.md
+++ b/.changeset/nervous-vans-appear.md
@@ -1,0 +1,5 @@
+---
+'@xstate/cli': patch
+---
+
+Fix getting env variables from import.meta.env.SOME_KEY

--- a/packages/machine-extractor/src/sky/skyConfigNode.ts
+++ b/packages/machine-extractor/src/sky/skyConfigNode.ts
@@ -33,7 +33,6 @@ const StringLiteralOrEnvKey = unionType([
             throw new Error("Couldn't find API key in any of the env files");
           }
 
-          // Let's find the last part of the expression (identifier), e.g. `API_KEY` in `process.env.API_KEY`
           // Let's find the last part of the expression, e.g. `API_KEY` in `process.env.API_KEY`
           const envVariableName = context
             .getNodeSource(node)

--- a/packages/machine-extractor/src/sky/skyConfigNode.ts
+++ b/packages/machine-extractor/src/sky/skyConfigNode.ts
@@ -33,12 +33,19 @@ const StringLiteralOrEnvKey = unionType([
             throw new Error("Couldn't find API key in any of the env files");
           }
 
-          // Let's find the last part of the expression, e.g. `API_KEY` in `process.env.API_KEY`
-          const envVariableName = context
-            .getNodeSource(node)
-            .match(/(?<=\.)(\w+)(?!.*\.)/);
-          if (envVariableName && envVariableName[0]) {
-            const value = context.getEnvVariable(envVariableName[0]);
+          // Let's find the env key, e.g. `API_KEY` in `process.env.API_KEY` or in `import.meta.env.API_KEY`
+          const envVariableName =
+            (t.buildMatchMemberExpression('process.env')(node.object) ||
+              (t.isMemberExpression(node.object) &&
+                t.isMetaProperty(node.object.object) &&
+                t.isIdentifier(node.object.property) &&
+                node.object.property.name === 'env')) &&
+            t.isIdentifier(node.property)
+              ? node.property.name
+              : null;
+
+          if (envVariableName) {
+            const value = context.getEnvVariable(envVariableName);
             if (!value) {
               throw new Error("Couldn't find API key in any of the env files");
             }

--- a/packages/machine-extractor/src/sky/skyConfigNode.ts
+++ b/packages/machine-extractor/src/sky/skyConfigNode.ts
@@ -34,15 +34,12 @@ const StringLiteralOrEnvKey = unionType([
           }
 
           // Let's find the last part of the expression (identifier), e.g. `API_KEY` in `process.env.API_KEY`
-          const envVariableName =
-            (t.isMetaProperty(node.object) ||
-              t.buildMatchMemberExpression('process.env')(node.object)) &&
-            t.isIdentifier(node.property)
-              ? node.property.name
-              : null;
-
-          if (envVariableName) {
-            const value = context.getEnvVariable(envVariableName);
+          // Let's find the last part of the expression, e.g. `API_KEY` in `process.env.API_KEY`
+          const envVariableName = context
+            .getNodeSource(node)
+            .match(/(?<=\.)(\w+)(?!.*\.)/);
+          if (envVariableName && envVariableName[0]) {
+            const value = context.getEnvVariable(envVariableName[0]);
             if (!value) {
               throw new Error("Couldn't find API key in any of the env files");
             }


### PR DESCRIPTION
Follow-up fix for #397.

I forgot that the Vite syntax is `import.meta.env.SOME_KEY` - we didn't handle the `env` part using the latest version. This PR reverts to using a Regex to grab the env variable name. Tested and works with both `process.env.SOME_KEY` and `import.meta.env.SOME_KEY`.
