### PR TITLE
Remove typegen `xsm` snippet

### DIFF
--- a/.changeset/yeti-cars-wink.md
+++ b/.changeset/yeti-cars-wink.md
@@ -1,0 +1,6 @@
+---
+'stately-vscode': minor
+'@xstate/vscode-server': minor
+---
+
+Removed "XState Typegen Machine" code snippet.

--- a/apps/extension/client/snippets/xstate.code-snippets
+++ b/apps/extension/client/snippets/xstate.code-snippets
@@ -1,20 +1,11 @@
 {
   "XState Machine": {
-    "scope": "javascript,javascriptreact,vue",
+    "scope": "javascript,javascriptreact,typescript,typescriptreact,vue",
     "prefix": "xsm",
     "body": [
       "import { createMachine } from 'xstate';",
       "const ${1:nameOf}Machine = createMachine({\n\tid: '${1:nameOf}',\n\tinitial: '${2:initialState}',\n\tstates: {\n\t\t${2:initialState}: {$0},\n\t}\n});"
     ],
     "description": "Outline for XState Machine"
-  },
-  "XState Typegen Machine": {
-    "scope": "typescript,typescriptreact,vue",
-    "prefix": "xsm",
-    "body": [
-      "import { createMachine } from 'xstate';",
-      "const ${1:nameOf}Machine = createMachine({\n\tid: '${1:nameOf}',\n\ttsTypes: {},\n\tschema: {\n\t\tcontext: {} as { ${2:contextType} },\n\t\tevents: {} as { type: '${3:eventType}' },\n\t},\n\tcontext: {\n\t\t${4:initialContextValue},\n\t},\n\tinitial: '${5:initialState}',\n\tstates: {\n\t\t${5:initialState}: {},\n\t},\n});$0"
-    ],
-    "description": "Outline for XState Typegen Machine"
   }
 }


### PR DESCRIPTION
This PR removes the typegen-specific `xsm` snippet. After we've released XState V5, this snippet isn't as helpful anymore, as types are handled differently now.