### PR TITLE
Extract `reenter` (and old `internal`) transition property

### DIFF
--- a/new-packages/ts-project/__tests__/actors.test.ts
+++ b/new-packages/ts-project/__tests__/actors.test.ts
@@ -75,6 +75,7 @@ test('should extract an actor with string src (direct)', async () => {
       ]
     `);
 });
+
 test('should extract multiple actors with different string sources (direct)', async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
@@ -208,6 +209,7 @@ test('should extract multiple actors with different string sources (direct)', as
       ]
     `);
 });
+
 test('should extract multiple actors with the same string source (direct)', async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
@@ -336,6 +338,7 @@ test('should extract multiple actors with the same string source (direct)', asyn
       ]
     `);
 });
+
 test('should extract multiple actors with string source (array)', async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
@@ -452,6 +455,7 @@ test('should extract multiple actors with string source (array)', async () => {
       ]
     `);
 });
+
 test('should extract actor with inline source (direct)', async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
@@ -585,6 +589,7 @@ test('should extract actor with inline source (direct)', async () => {
       ]
     `);
 });
+
 test('should raise error if actor is missing src property', async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
@@ -663,6 +668,7 @@ test('should raise error if actor is missing src property', async () => {
     ]
   `);
 });
+
 test('should extract actor id if it is present with a string value', async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),

--- a/new-packages/ts-project/__tests__/guards.test.ts
+++ b/new-packages/ts-project/__tests__/guards.test.ts
@@ -134,6 +134,7 @@ test('should extract guard from transition (string)', async () => {
       ]
     `);
 });
+
 test('should extract guard (inline)', async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
@@ -267,6 +268,7 @@ test('should extract guard (inline)', async () => {
       ]
     `);
 });
+
 test('should extract parameterized guards', async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
@@ -402,6 +404,7 @@ test('should extract parameterized guards', async () => {
       ]
     `);
 });
+
 test('should extract higher order guards as inline', async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
@@ -535,6 +538,7 @@ test('should extract higher order guards as inline', async () => {
       ]
     `);
 });
+
 test('should extract multiple guards', async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
@@ -767,6 +771,7 @@ test('should extract multiple guards', async () => {
       ]
     `);
 });
+
 test('should support XState v4 guard', async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
@@ -900,6 +905,7 @@ test('should support XState v4 guard', async () => {
       ]
     `);
 });
+
 test('should raise error if both guard and cond are provided, pick guard over cond and extract transition (cond before guard)', async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
@@ -1298,6 +1304,7 @@ test('should raise error for parameterized guard is missing type property', asyn
       ]
     `);
 });
+
 test('should raise error for parameterized guard with invalid type property', async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),

--- a/new-packages/ts-project/__tests__/state.test.ts
+++ b/new-packages/ts-project/__tests__/state.test.ts
@@ -275,6 +275,7 @@ test('should extract state.initial with string value', async () => {
       ]
     `);
 });
+
 test('should extract state.initial with template literal value', async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
@@ -804,6 +805,7 @@ test('should extract state.history with value "shallow"', async () => {
       ]
     `);
 });
+
 test('should extract state.history with value "deep"', async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
@@ -1455,6 +1457,7 @@ test("should extract state.meta when it's a javascript object", async () => {
       ]
     `);
 });
+
 test("should extract state.meta when it's a javascript object containing nested array items", async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
@@ -1550,6 +1553,7 @@ test("should extract state.meta when it's a javascript object containing nested 
       ]
     `);
 });
+
 test("should extract state.meta when it's a javascript object and contains multi level object value", async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
@@ -1732,7 +1736,7 @@ test('should raise error when state.meta contains any value other than a plain j
         initial: 'foo'
         states: {
           foo: {
-            meta: 'some string meta' 
+            meta: 'some string meta'
           }
         },
       });

--- a/new-packages/ts-project/__tests__/transitions.test.ts
+++ b/new-packages/ts-project/__tests__/transitions.test.ts
@@ -3061,6 +3061,7 @@ test('should extract transition description (multi-line)', async () => {
       ]
     `);
 });
+
 test('should extract state.onDone transition (direct string)', async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
@@ -3178,26 +3179,26 @@ test("should extract transition.meta when it's a javascript object", async () =>
     'index.ts': ts`
       import { createMachine } from "xstate";
       createMachine({
-        initial: 'foo'
+        initial: "foo",
         states: {
           foo: {
             on: {
               EV: {
-                target: 'bar',
+                target: "bar",
                 meta: {
-                  str: 'some string',
+                  str: "some string",
                   num: 123,
                   bool: true,
                   arr: [1, 2, 3],
                   obj: {
-                    foo: 'bar'
+                    foo: "bar",
                   },
-                  null: null
-                }
-              }
-            }
+                  null: null,
+                },
+              },
+            },
           },
-          bar: {}
+          bar: {},
         },
       });
     `,
@@ -3328,25 +3329,26 @@ test("should extract transition.meta when it's a javascript object", async () =>
       ]
     `);
 });
+
 test("should extract transition.meta when it's a javascript object containing nested array items", async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
     'index.ts': ts`
       import { createMachine } from "xstate";
       createMachine({
-        initial: 'foo'
+        initial: "foo",
         states: {
           foo: {
             on: {
               EV: {
-                target: 'bar',
+                target: "bar",
                 meta: {
-                  arr: ['str', 123, true, [1, 2, 3], { foo: 'bar' }, null]
-                }
-              }
-            }
+                  arr: ["str", 123, true, [1, 2, 3], { foo: "bar" }, null],
+                },
+              },
+            },
           },
-          bar: {}
+          bar: {},
         },
       });
     `,
@@ -3464,31 +3466,32 @@ test("should extract transition.meta when it's a javascript object containing ne
     ]
   `);
 });
+
 test("should extract transition.meta when it's a javascript object and contains multi level object value", async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
     'index.ts': ts`
       import { createMachine } from "xstate";
       createMachine({
-        initial: 'foo'
+        initial: "foo",
         states: {
           foo: {
             on: {
               EV: {
-                target: 'bar',
+                target: "bar",
                 meta: {
                   obj: {
                     x: {
                       y: {
-                        z: 'some string'
-                      }
-                    }
-                  }
-                }
-              }
-            }
+                        z: "some string",
+                      },
+                    },
+                  },
+                },
+              },
+            },
           },
-          bar: {}
+          bar: {},
         },
       });
     `,
@@ -3606,17 +3609,17 @@ test('should not raise error for transition.meta with undefined value', async ()
     'index.ts': ts`
       import { createMachine } from "xstate";
       createMachine({
-        initial: 'foo'
+        initial: "foo",
         states: {
           foo: {
             on: {
               EV: {
-                target: 'bar',
-                meta: undefined
-              }
-            }
+                target: "bar",
+                meta: undefined,
+              },
+            },
           },
-          bar: {}
+          bar: {},
         },
       });
     `,
@@ -3724,17 +3727,17 @@ test('should raise error when transition.meta contains any value other than a pl
     'index.ts': ts`
       import { createMachine } from "xstate";
       createMachine({
-        initial: 'foo'
+        initial: "foo",
         states: {
           foo: {
             on: {
               EV: {
-                target: 'bar',
-                meta: 'some string meta'
-              }
-            }
+                target: "bar",
+                meta: "some string meta",
+              },
+            },
           },
-          bar: {}
+          bar: {},
         },
       });
     `,
@@ -3838,6 +3841,7 @@ test('should raise error when transition.meta contains any value other than a pl
       ]
     `);
 });
+
 test('should extract after transition (number delay)', async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
@@ -3861,95 +3865,97 @@ test('should extract after transition (number delay)', async () => {
   const project = await createTestProject(tmpPath);
   expect(replaceUniqueIds(project.extractMachines('index.ts')))
     .toMatchInlineSnapshot(`
-    [
       [
-        {
-          "blocks": {},
-          "data": {
-            "context": {},
-          },
-          "edges": {
-            "edge-0": {
-              "data": {
-                "actions": [],
-                "description": undefined,
-                "eventTypeData": {
-                  "delay": "100",
-                  "type": "after",
+        [
+          {
+            "blocks": {},
+            "data": {
+              "context": {},
+            },
+            "edges": {
+              "edge-0": {
+                "data": {
+                  "actions": [],
+                  "description": undefined,
+                  "eventTypeData": {
+                    "delay": "100",
+                    "type": "after",
+                  },
+                  "guard": undefined,
+                  "internal": true,
+                  "metaEntries": [],
                 },
-                "guard": undefined,
-                "internal": true,
+                "source": "state-1",
+                "targets": [
+                  "state-2",
+                ],
+                "type": "edge",
+                "uniqueId": "edge-0",
               },
-              "source": "state-1",
-              "targets": [
-                "state-2",
-              ],
-              "type": "edge",
-              "uniqueId": "edge-0",
             },
+            "implementations": {
+              "actions": {},
+              "actors": {},
+              "guards": {},
+            },
+            "nodes": {
+              "state-0": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": "foo",
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": undefined,
+                "type": "node",
+                "uniqueId": "state-0",
+              },
+              "state-1": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-1",
+              },
+              "state-2": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-2",
+              },
+            },
+            "root": "state-0",
           },
-          "implementations": {
-            "actions": {},
-            "actors": {},
-            "guards": {},
-          },
-          "nodes": {
-            "state-0": {
-              "data": {
-                "description": undefined,
-                "entry": [],
-                "exit": [],
-                "history": undefined,
-                "initial": "foo",
-                "invoke": [],
-                "metaEntries": [],
-                "tags": [],
-                "type": "normal",
-              },
-              "parentId": undefined,
-              "type": "node",
-              "uniqueId": "state-0",
-            },
-            "state-1": {
-              "data": {
-                "description": undefined,
-                "entry": [],
-                "exit": [],
-                "history": undefined,
-                "initial": undefined,
-                "invoke": [],
-                "metaEntries": [],
-                "tags": [],
-                "type": "normal",
-              },
-              "parentId": "state-0",
-              "type": "node",
-              "uniqueId": "state-1",
-            },
-            "state-2": {
-              "data": {
-                "description": undefined,
-                "entry": [],
-                "exit": [],
-                "history": undefined,
-                "initial": undefined,
-                "invoke": [],
-                "metaEntries": [],
-                "tags": [],
-                "type": "normal",
-              },
-              "parentId": "state-0",
-              "type": "node",
-              "uniqueId": "state-2",
-            },
-          },
-          "root": "state-0",
-        },
-        [],
-      ],
-    ]
-  `);
+          [],
+        ],
+      ]
+    `);
 });
+
 test('should extract delayed transition (identifier delay)', async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
@@ -3973,95 +3979,97 @@ test('should extract delayed transition (identifier delay)', async () => {
   const project = await createTestProject(tmpPath);
   expect(replaceUniqueIds(project.extractMachines('index.ts')))
     .toMatchInlineSnapshot(`
-    [
       [
-        {
-          "blocks": {},
-          "data": {
-            "context": {},
-          },
-          "edges": {
-            "edge-0": {
-              "data": {
-                "actions": [],
-                "description": undefined,
-                "eventTypeData": {
-                  "delay": "myDelay",
-                  "type": "after",
+        [
+          {
+            "blocks": {},
+            "data": {
+              "context": {},
+            },
+            "edges": {
+              "edge-0": {
+                "data": {
+                  "actions": [],
+                  "description": undefined,
+                  "eventTypeData": {
+                    "delay": "myDelay",
+                    "type": "after",
+                  },
+                  "guard": undefined,
+                  "internal": true,
+                  "metaEntries": [],
                 },
-                "guard": undefined,
-                "internal": true,
+                "source": "state-1",
+                "targets": [
+                  "state-2",
+                ],
+                "type": "edge",
+                "uniqueId": "edge-0",
               },
-              "source": "state-1",
-              "targets": [
-                "state-2",
-              ],
-              "type": "edge",
-              "uniqueId": "edge-0",
             },
+            "implementations": {
+              "actions": {},
+              "actors": {},
+              "guards": {},
+            },
+            "nodes": {
+              "state-0": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": "foo",
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": undefined,
+                "type": "node",
+                "uniqueId": "state-0",
+              },
+              "state-1": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-1",
+              },
+              "state-2": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-2",
+              },
+            },
+            "root": "state-0",
           },
-          "implementations": {
-            "actions": {},
-            "actors": {},
-            "guards": {},
-          },
-          "nodes": {
-            "state-0": {
-              "data": {
-                "description": undefined,
-                "entry": [],
-                "exit": [],
-                "history": undefined,
-                "initial": "foo",
-                "invoke": [],
-                "metaEntries": [],
-                "tags": [],
-                "type": "normal",
-              },
-              "parentId": undefined,
-              "type": "node",
-              "uniqueId": "state-0",
-            },
-            "state-1": {
-              "data": {
-                "description": undefined,
-                "entry": [],
-                "exit": [],
-                "history": undefined,
-                "initial": undefined,
-                "invoke": [],
-                "metaEntries": [],
-                "tags": [],
-                "type": "normal",
-              },
-              "parentId": "state-0",
-              "type": "node",
-              "uniqueId": "state-1",
-            },
-            "state-2": {
-              "data": {
-                "description": undefined,
-                "entry": [],
-                "exit": [],
-                "history": undefined,
-                "initial": undefined,
-                "invoke": [],
-                "metaEntries": [],
-                "tags": [],
-                "type": "normal",
-              },
-              "parentId": "state-0",
-              "type": "node",
-              "uniqueId": "state-2",
-            },
-          },
-          "root": "state-0",
-        },
-        [],
-      ],
-    ]
-  `);
+          [],
+        ],
+      ]
+    `);
 });
+
 test('should extract after transition (string with whitespace delay)', async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
@@ -4085,95 +4093,97 @@ test('should extract after transition (string with whitespace delay)', async () 
   const project = await createTestProject(tmpPath);
   expect(replaceUniqueIds(project.extractMachines('index.ts')))
     .toMatchInlineSnapshot(`
-    [
       [
-        {
-          "blocks": {},
-          "data": {
-            "context": {},
-          },
-          "edges": {
-            "edge-0": {
-              "data": {
-                "actions": [],
-                "description": undefined,
-                "eventTypeData": {
-                  "delay": "named delay",
-                  "type": "after",
+        [
+          {
+            "blocks": {},
+            "data": {
+              "context": {},
+            },
+            "edges": {
+              "edge-0": {
+                "data": {
+                  "actions": [],
+                  "description": undefined,
+                  "eventTypeData": {
+                    "delay": "my delay",
+                    "type": "after",
+                  },
+                  "guard": undefined,
+                  "internal": true,
+                  "metaEntries": [],
                 },
-                "guard": undefined,
-                "internal": true,
+                "source": "state-1",
+                "targets": [
+                  "state-2",
+                ],
+                "type": "edge",
+                "uniqueId": "edge-0",
               },
-              "source": "state-1",
-              "targets": [
-                "state-2",
-              ],
-              "type": "edge",
-              "uniqueId": "edge-0",
             },
+            "implementations": {
+              "actions": {},
+              "actors": {},
+              "guards": {},
+            },
+            "nodes": {
+              "state-0": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": "foo",
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": undefined,
+                "type": "node",
+                "uniqueId": "state-0",
+              },
+              "state-1": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-1",
+              },
+              "state-2": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-2",
+              },
+            },
+            "root": "state-0",
           },
-          "implementations": {
-            "actions": {},
-            "actors": {},
-            "guards": {},
-          },
-          "nodes": {
-            "state-0": {
-              "data": {
-                "description": undefined,
-                "entry": [],
-                "exit": [],
-                "history": undefined,
-                "initial": "foo",
-                "invoke": [],
-                "metaEntries": [],
-                "tags": [],
-                "type": "normal",
-              },
-              "parentId": undefined,
-              "type": "node",
-              "uniqueId": "state-0",
-            },
-            "state-1": {
-              "data": {
-                "description": undefined,
-                "entry": [],
-                "exit": [],
-                "history": undefined,
-                "initial": undefined,
-                "invoke": [],
-                "metaEntries": [],
-                "tags": [],
-                "type": "normal",
-              },
-              "parentId": "state-0",
-              "type": "node",
-              "uniqueId": "state-1",
-            },
-            "state-2": {
-              "data": {
-                "description": undefined,
-                "entry": [],
-                "exit": [],
-                "history": undefined,
-                "initial": undefined,
-                "invoke": [],
-                "metaEntries": [],
-                "tags": [],
-                "type": "normal",
-              },
-              "parentId": "state-0",
-              "type": "node",
-              "uniqueId": "state-2",
-            },
-          },
-          "root": "state-0",
-        },
-        [],
-      ],
-    ]
-  `);
+          [],
+        ],
+      ]
+    `);
 });
+
 test('should extract multiple delayed transitions', async () => {
   const tmpPath = await testdir({
     'tsconfig.json': JSON.stringify({}),
@@ -4199,143 +4209,1915 @@ test('should extract multiple delayed transitions', async () => {
   const project = await createTestProject(tmpPath);
   expect(replaceUniqueIds(project.extractMachines('index.ts')))
     .toMatchInlineSnapshot(`
-    [
       [
-        {
-          "blocks": {
-            "block-0": {
-              "blockType": "guard",
-              "parentId": "edge-1",
-              "properties": {
-                "params": {},
-                "type": "condition",
-              },
-              "sourceId": "condition",
-              "uniqueId": "block-0",
-            },
-          },
-          "data": {
-            "context": {},
-          },
-          "edges": {
-            "edge-0": {
-              "data": {
-                "actions": [],
-                "description": undefined,
-                "eventTypeData": {
-                  "delay": "200",
-                  "type": "after",
+        [
+          {
+            "blocks": {
+              "block-0": {
+                "blockType": "guard",
+                "parentId": "edge-1",
+                "properties": {
+                  "params": {},
+                  "type": "condition",
                 },
-                "guard": undefined,
-                "internal": true,
+                "sourceId": "condition",
+                "uniqueId": "block-0",
               },
-              "source": "state-1",
-              "targets": [
-                "state-3",
-              ],
-              "type": "edge",
-              "uniqueId": "edge-0",
             },
-            "edge-1": {
-              "data": {
-                "actions": [],
-                "description": undefined,
-                "eventTypeData": {
-                  "delay": "100",
-                  "type": "after",
+            "data": {
+              "context": {},
+            },
+            "edges": {
+              "edge-0": {
+                "data": {
+                  "actions": [],
+                  "description": undefined,
+                  "eventTypeData": {
+                    "delay": "200",
+                    "type": "after",
+                  },
+                  "guard": undefined,
+                  "internal": true,
+                  "metaEntries": [],
                 },
-                "guard": "block-0",
-                "internal": true,
+                "source": "state-1",
+                "targets": [
+                  "state-3",
+                ],
+                "type": "edge",
+                "uniqueId": "edge-0",
               },
-              "source": "state-1",
-              "targets": [
-                "state-2",
-              ],
-              "type": "edge",
-              "uniqueId": "edge-1",
+              "edge-1": {
+                "data": {
+                  "actions": [],
+                  "description": undefined,
+                  "eventTypeData": {
+                    "delay": "100",
+                    "type": "after",
+                  },
+                  "guard": "block-0",
+                  "internal": true,
+                  "metaEntries": [],
+                },
+                "source": "state-1",
+                "targets": [
+                  "state-2",
+                ],
+                "type": "edge",
+                "uniqueId": "edge-1",
+              },
+            },
+            "implementations": {
+              "actions": {},
+              "actors": {},
+              "guards": {
+                "condition": {
+                  "id": "condition",
+                  "name": "condition",
+                  "type": "guard",
+                },
+              },
+            },
+            "nodes": {
+              "state-0": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": "foo",
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": undefined,
+                "type": "node",
+                "uniqueId": "state-0",
+              },
+              "state-1": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-1",
+              },
+              "state-2": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-2",
+              },
+              "state-3": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-3",
+              },
+            },
+            "root": "state-0",
+          },
+          [],
+        ],
+      ]
+    `);
+});
+
+test('should extract a sibling transition as internal by default (direct string)', async () => {
+  const tmpPath = await testdir({
+    'tsconfig.json': JSON.stringify({}),
+    'index.ts': ts`
+      import { createMachine } from "xstate";
+
+      createMachine({
+        initial: "foo",
+        states: {
+          foo: {
+            on: {
+              FOO: "bar",
             },
           },
-          "implementations": {
-            "actions": {},
-            "actors": {},
-            "guards": {
-              "condition": {
-                "id": "condition",
-                "name": "condition",
-                "type": "guard",
-              },
-            },
-          },
-          "nodes": {
-            "state-0": {
-              "data": {
-                "description": undefined,
-                "entry": [],
-                "exit": [],
-                "history": undefined,
-                "initial": "foo",
-                "invoke": [],
-                "metaEntries": [],
-                "tags": [],
-                "type": "normal",
-              },
-              "parentId": undefined,
-              "type": "node",
-              "uniqueId": "state-0",
-            },
-            "state-1": {
-              "data": {
-                "description": undefined,
-                "entry": [],
-                "exit": [],
-                "history": undefined,
-                "initial": undefined,
-                "invoke": [],
-                "metaEntries": [],
-                "tags": [],
-                "type": "normal",
-              },
-              "parentId": "state-0",
-              "type": "node",
-              "uniqueId": "state-1",
-            },
-            "state-2": {
-              "data": {
-                "description": undefined,
-                "entry": [],
-                "exit": [],
-                "history": undefined,
-                "initial": undefined,
-                "invoke": [],
-                "metaEntries": [],
-                "tags": [],
-                "type": "normal",
-              },
-              "parentId": "state-0",
-              "type": "node",
-              "uniqueId": "state-2",
-            },
-            "state-3": {
-              "data": {
-                "description": undefined,
-                "entry": [],
-                "exit": [],
-                "history": undefined,
-                "initial": undefined,
-                "invoke": [],
-                "metaEntries": [],
-                "tags": [],
-                "type": "normal",
-              },
-              "parentId": "state-0",
-              "type": "node",
-              "uniqueId": "state-3",
-            },
-          },
-          "root": "state-0",
+          bar: {},
         },
-        [],
-      ],
-    ]
-  `);
+      });
+    `,
+  });
+
+  const project = await createTestProject(tmpPath);
+  expect(replaceUniqueIds(project.extractMachines('index.ts')))
+    .toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "blocks": {},
+            "data": {
+              "context": {},
+            },
+            "edges": {
+              "edge-0": {
+                "data": {
+                  "actions": [],
+                  "description": undefined,
+                  "eventTypeData": {
+                    "eventType": "FOO",
+                    "type": "named",
+                  },
+                  "guard": undefined,
+                  "internal": true,
+                  "metaEntries": [],
+                },
+                "source": "state-1",
+                "targets": [
+                  "state-2",
+                ],
+                "type": "edge",
+                "uniqueId": "edge-0",
+              },
+            },
+            "implementations": {
+              "actions": {},
+              "actors": {},
+              "guards": {},
+            },
+            "nodes": {
+              "state-0": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": "foo",
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": undefined,
+                "type": "node",
+                "uniqueId": "state-0",
+              },
+              "state-1": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-1",
+              },
+              "state-2": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-2",
+              },
+            },
+            "root": "state-0",
+          },
+          [],
+        ],
+      ]
+    `);
+});
+
+test('should extract a descendant transition as internal by default (direct string)', async () => {
+  const tmpPath = await testdir({
+    'tsconfig.json': JSON.stringify({}),
+    'index.ts': ts`
+      import { createMachine } from "xstate";
+
+      createMachine({
+        initial: "foo",
+        states: {
+          foo: {
+            on: {
+              FOO: ".bar",
+            },
+            states: {
+              bar: {},
+            },
+          },
+        },
+      });
+    `,
+  });
+
+  const project = await createTestProject(tmpPath);
+  expect(replaceUniqueIds(project.extractMachines('index.ts')))
+    .toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "blocks": {},
+            "data": {
+              "context": {},
+            },
+            "edges": {
+              "edge-0": {
+                "data": {
+                  "actions": [],
+                  "description": undefined,
+                  "eventTypeData": {
+                    "eventType": "FOO",
+                    "type": "named",
+                  },
+                  "guard": undefined,
+                  "internal": true,
+                  "metaEntries": [],
+                },
+                "source": "state-1",
+                "targets": [
+                  "state-2",
+                ],
+                "type": "edge",
+                "uniqueId": "edge-0",
+              },
+            },
+            "implementations": {
+              "actions": {},
+              "actors": {},
+              "guards": {},
+            },
+            "nodes": {
+              "state-0": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": "foo",
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": undefined,
+                "type": "node",
+                "uniqueId": "state-0",
+              },
+              "state-1": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-1",
+              },
+              "state-2": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-1",
+                "type": "node",
+                "uniqueId": "state-2",
+              },
+            },
+            "root": "state-0",
+          },
+          [],
+        ],
+      ]
+    `);
+});
+
+test('should extract a sibling transition as internal by default (direct object with target)', async () => {
+  const tmpPath = await testdir({
+    'tsconfig.json': JSON.stringify({}),
+    'index.ts': ts`
+      import { createMachine } from "xstate";
+
+      createMachine({
+        initial: "foo",
+        states: {
+          foo: {
+            on: {
+              FOO: { target: "bar" },
+            },
+          },
+          bar: {},
+        },
+      });
+    `,
+  });
+
+  const project = await createTestProject(tmpPath);
+  expect(replaceUniqueIds(project.extractMachines('index.ts')))
+    .toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "blocks": {},
+            "data": {
+              "context": {},
+            },
+            "edges": {
+              "edge-0": {
+                "data": {
+                  "actions": [],
+                  "description": undefined,
+                  "eventTypeData": {
+                    "eventType": "FOO",
+                    "type": "named",
+                  },
+                  "guard": undefined,
+                  "internal": true,
+                  "metaEntries": [],
+                },
+                "source": "state-1",
+                "targets": [
+                  "state-2",
+                ],
+                "type": "edge",
+                "uniqueId": "edge-0",
+              },
+            },
+            "implementations": {
+              "actions": {},
+              "actors": {},
+              "guards": {},
+            },
+            "nodes": {
+              "state-0": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": "foo",
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": undefined,
+                "type": "node",
+                "uniqueId": "state-0",
+              },
+              "state-1": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-1",
+              },
+              "state-2": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-2",
+              },
+            },
+            "root": "state-0",
+          },
+          [],
+        ],
+      ]
+    `);
+});
+
+test('should extract a descendant transition as internal by default (direct object with target)', async () => {
+  const tmpPath = await testdir({
+    'tsconfig.json': JSON.stringify({}),
+    'index.ts': ts`
+      import { createMachine } from "xstate";
+
+      createMachine({
+        initial: "foo",
+        states: {
+          foo: {
+            on: {
+              FOO: {
+                target: ".bar",
+              },
+            },
+            states: {
+              bar: {},
+            },
+          },
+        },
+      });
+    `,
+  });
+
+  const project = await createTestProject(tmpPath);
+  expect(replaceUniqueIds(project.extractMachines('index.ts')))
+    .toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "blocks": {},
+            "data": {
+              "context": {},
+            },
+            "edges": {
+              "edge-0": {
+                "data": {
+                  "actions": [],
+                  "description": undefined,
+                  "eventTypeData": {
+                    "eventType": "FOO",
+                    "type": "named",
+                  },
+                  "guard": undefined,
+                  "internal": true,
+                  "metaEntries": [],
+                },
+                "source": "state-1",
+                "targets": [
+                  "state-2",
+                ],
+                "type": "edge",
+                "uniqueId": "edge-0",
+              },
+            },
+            "implementations": {
+              "actions": {},
+              "actors": {},
+              "guards": {},
+            },
+            "nodes": {
+              "state-0": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": "foo",
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": undefined,
+                "type": "node",
+                "uniqueId": "state-0",
+              },
+              "state-1": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-1",
+              },
+              "state-2": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-1",
+                "type": "node",
+                "uniqueId": "state-2",
+              },
+            },
+            "root": "state-0",
+          },
+          [],
+        ],
+      ]
+    `);
+});
+
+test('should extract an explicit reentering transition as not internal', async () => {
+  const tmpPath = await testdir({
+    'tsconfig.json': JSON.stringify({}),
+    'index.ts': ts`
+      import { createMachine } from "xstate";
+
+      createMachine({
+        initial: "foo",
+        states: {
+          foo: {
+            on: {
+              FOO: { target: "bar", reenter: true },
+            },
+          },
+          bar: {},
+        },
+      });
+    `,
+  });
+
+  const project = await createTestProject(tmpPath);
+  expect(replaceUniqueIds(project.extractMachines('index.ts')))
+    .toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "blocks": {},
+            "data": {
+              "context": {},
+            },
+            "edges": {
+              "edge-0": {
+                "data": {
+                  "actions": [],
+                  "description": undefined,
+                  "eventTypeData": {
+                    "eventType": "FOO",
+                    "type": "named",
+                  },
+                  "guard": undefined,
+                  "internal": false,
+                  "metaEntries": [],
+                },
+                "source": "state-1",
+                "targets": [
+                  "state-2",
+                ],
+                "type": "edge",
+                "uniqueId": "edge-0",
+              },
+            },
+            "implementations": {
+              "actions": {},
+              "actors": {},
+              "guards": {},
+            },
+            "nodes": {
+              "state-0": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": "foo",
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": undefined,
+                "type": "node",
+                "uniqueId": "state-0",
+              },
+              "state-1": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-1",
+              },
+              "state-2": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-2",
+              },
+            },
+            "root": "state-0",
+          },
+          [],
+        ],
+      ]
+    `);
+});
+
+test('should extract an explicit non-reentering transition as internal', async () => {
+  const tmpPath = await testdir({
+    'tsconfig.json': JSON.stringify({}),
+    'index.ts': ts`
+      import { createMachine } from "xstate";
+
+      createMachine({
+        initial: "foo",
+        states: {
+          foo: {
+            on: {
+              FOO: { target: "bar", reenter: false },
+            },
+          },
+          bar: {},
+        },
+      });
+    `,
+  });
+
+  const project = await createTestProject(tmpPath);
+  expect(replaceUniqueIds(project.extractMachines('index.ts')))
+    .toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "blocks": {},
+            "data": {
+              "context": {},
+            },
+            "edges": {
+              "edge-0": {
+                "data": {
+                  "actions": [],
+                  "description": undefined,
+                  "eventTypeData": {
+                    "eventType": "FOO",
+                    "type": "named",
+                  },
+                  "guard": undefined,
+                  "internal": true,
+                  "metaEntries": [],
+                },
+                "source": "state-1",
+                "targets": [
+                  "state-2",
+                ],
+                "type": "edge",
+                "uniqueId": "edge-0",
+              },
+            },
+            "implementations": {
+              "actions": {},
+              "actors": {},
+              "guards": {},
+            },
+            "nodes": {
+              "state-0": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": "foo",
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": undefined,
+                "type": "node",
+                "uniqueId": "state-0",
+              },
+              "state-1": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-1",
+              },
+              "state-2": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-2",
+              },
+            },
+            "root": "state-0",
+          },
+          [],
+        ],
+      ]
+    `);
+});
+
+test('should extract a sibling transition as not internal by default (direct string, v4)', async () => {
+  const tmpPath = await testdir({
+    'tsconfig.json': JSON.stringify({}),
+    'index.ts': ts`
+      import { createMachine } from "xstate";
+
+      createMachine({
+        initial: "foo",
+        states: {
+          foo: {
+            on: {
+              FOO: "bar",
+            },
+          },
+          bar: {},
+        },
+      });
+    `,
+  });
+
+  const project = await createTestProject(tmpPath, { version: 'v4' });
+  expect(replaceUniqueIds(project.extractMachines('index.ts')))
+    .toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "blocks": {},
+            "data": {
+              "context": {},
+            },
+            "edges": {
+              "edge-0": {
+                "data": {
+                  "actions": [],
+                  "description": undefined,
+                  "eventTypeData": {
+                    "eventType": "FOO",
+                    "type": "named",
+                  },
+                  "guard": undefined,
+                  "internal": false,
+                  "metaEntries": [],
+                },
+                "source": "state-1",
+                "targets": [
+                  "state-2",
+                ],
+                "type": "edge",
+                "uniqueId": "edge-0",
+              },
+            },
+            "implementations": {
+              "actions": {},
+              "actors": {},
+              "guards": {},
+            },
+            "nodes": {
+              "state-0": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": "foo",
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": undefined,
+                "type": "node",
+                "uniqueId": "state-0",
+              },
+              "state-1": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-1",
+              },
+              "state-2": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-2",
+              },
+            },
+            "root": "state-0",
+          },
+          [],
+        ],
+      ]
+    `);
+});
+
+test('should extract a descendant transition as internal by default (direct string, v4)', async () => {
+  const tmpPath = await testdir({
+    'tsconfig.json': JSON.stringify({}),
+    'index.ts': ts`
+      import { createMachine } from "xstate";
+
+      createMachine({
+        initial: "foo",
+        states: {
+          foo: {
+            on: {
+              FOO: ".bar",
+            },
+            states: {
+              bar: {},
+            },
+          },
+        },
+      });
+    `,
+  });
+
+  const project = await createTestProject(tmpPath, { version: 'v4' });
+  expect(replaceUniqueIds(project.extractMachines('index.ts')))
+    .toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "blocks": {},
+            "data": {
+              "context": {},
+            },
+            "edges": {
+              "edge-0": {
+                "data": {
+                  "actions": [],
+                  "description": undefined,
+                  "eventTypeData": {
+                    "eventType": "FOO",
+                    "type": "named",
+                  },
+                  "guard": undefined,
+                  "internal": true,
+                  "metaEntries": [],
+                },
+                "source": "state-1",
+                "targets": [
+                  "state-2",
+                ],
+                "type": "edge",
+                "uniqueId": "edge-0",
+              },
+            },
+            "implementations": {
+              "actions": {},
+              "actors": {},
+              "guards": {},
+            },
+            "nodes": {
+              "state-0": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": "foo",
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": undefined,
+                "type": "node",
+                "uniqueId": "state-0",
+              },
+              "state-1": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-1",
+              },
+              "state-2": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-1",
+                "type": "node",
+                "uniqueId": "state-2",
+              },
+            },
+            "root": "state-0",
+          },
+          [],
+        ],
+      ]
+    `);
+});
+
+test('should extract a sibling transition as internal by default (direct object with target, v4)', async () => {
+  const tmpPath = await testdir({
+    'tsconfig.json': JSON.stringify({}),
+    'index.ts': ts`
+      import { createMachine } from "xstate";
+
+      createMachine({
+        initial: "foo",
+        states: {
+          foo: {
+            on: {
+              FOO: { target: "bar" },
+            },
+          },
+          bar: {},
+        },
+      });
+    `,
+  });
+
+  const project = await createTestProject(tmpPath, { version: 'v4' });
+  expect(replaceUniqueIds(project.extractMachines('index.ts')))
+    .toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "blocks": {},
+            "data": {
+              "context": {},
+            },
+            "edges": {
+              "edge-0": {
+                "data": {
+                  "actions": [],
+                  "description": undefined,
+                  "eventTypeData": {
+                    "eventType": "FOO",
+                    "type": "named",
+                  },
+                  "guard": undefined,
+                  "internal": false,
+                  "metaEntries": [],
+                },
+                "source": "state-1",
+                "targets": [
+                  "state-2",
+                ],
+                "type": "edge",
+                "uniqueId": "edge-0",
+              },
+            },
+            "implementations": {
+              "actions": {},
+              "actors": {},
+              "guards": {},
+            },
+            "nodes": {
+              "state-0": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": "foo",
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": undefined,
+                "type": "node",
+                "uniqueId": "state-0",
+              },
+              "state-1": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-1",
+              },
+              "state-2": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-2",
+              },
+            },
+            "root": "state-0",
+          },
+          [],
+        ],
+      ]
+    `);
+});
+
+test('should extract a descendant transition as internal by default (direct object with target, v4)', async () => {
+  const tmpPath = await testdir({
+    'tsconfig.json': JSON.stringify({}),
+    'index.ts': ts`
+      import { createMachine } from "xstate";
+
+      createMachine({
+        initial: "foo",
+        states: {
+          foo: {
+            on: {
+              FOO: {
+                target: ".bar",
+              },
+            },
+            states: {
+              bar: {},
+            },
+          },
+        },
+      });
+    `,
+  });
+
+  const project = await createTestProject(tmpPath, { version: 'v4' });
+  expect(replaceUniqueIds(project.extractMachines('index.ts')))
+    .toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "blocks": {},
+            "data": {
+              "context": {},
+            },
+            "edges": {
+              "edge-0": {
+                "data": {
+                  "actions": [],
+                  "description": undefined,
+                  "eventTypeData": {
+                    "eventType": "FOO",
+                    "type": "named",
+                  },
+                  "guard": undefined,
+                  "internal": true,
+                  "metaEntries": [],
+                },
+                "source": "state-1",
+                "targets": [
+                  "state-2",
+                ],
+                "type": "edge",
+                "uniqueId": "edge-0",
+              },
+            },
+            "implementations": {
+              "actions": {},
+              "actors": {},
+              "guards": {},
+            },
+            "nodes": {
+              "state-0": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": "foo",
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": undefined,
+                "type": "node",
+                "uniqueId": "state-0",
+              },
+              "state-1": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-1",
+              },
+              "state-2": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-1",
+                "type": "node",
+                "uniqueId": "state-2",
+              },
+            },
+            "root": "state-0",
+          },
+          [],
+        ],
+      ]
+    `);
+});
+
+test('should extract an explicit internal transition as internal (v4)', async () => {
+  const tmpPath = await testdir({
+    'tsconfig.json': JSON.stringify({}),
+    'index.ts': ts`
+      import { createMachine } from "xstate";
+
+      createMachine({
+        initial: "foo",
+        states: {
+          foo: {
+            on: {
+              FOO: { target: "bar", internal: true },
+            },
+          },
+          bar: {},
+        },
+      });
+    `,
+  });
+
+  const project = await createTestProject(tmpPath, { version: 'v4' });
+  expect(replaceUniqueIds(project.extractMachines('index.ts')))
+    .toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "blocks": {},
+            "data": {
+              "context": {},
+            },
+            "edges": {
+              "edge-0": {
+                "data": {
+                  "actions": [],
+                  "description": undefined,
+                  "eventTypeData": {
+                    "eventType": "FOO",
+                    "type": "named",
+                  },
+                  "guard": undefined,
+                  "internal": true,
+                  "metaEntries": [],
+                },
+                "source": "state-1",
+                "targets": [
+                  "state-2",
+                ],
+                "type": "edge",
+                "uniqueId": "edge-0",
+              },
+            },
+            "implementations": {
+              "actions": {},
+              "actors": {},
+              "guards": {},
+            },
+            "nodes": {
+              "state-0": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": "foo",
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": undefined,
+                "type": "node",
+                "uniqueId": "state-0",
+              },
+              "state-1": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-1",
+              },
+              "state-2": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-2",
+              },
+            },
+            "root": "state-0",
+          },
+          [],
+        ],
+      ]
+    `);
+});
+
+test('should extract an explicit non-internal transition as not internal (v4)', async () => {
+  const tmpPath = await testdir({
+    'tsconfig.json': JSON.stringify({}),
+    'index.ts': ts`
+      import { createMachine } from "xstate";
+
+      createMachine({
+        initial: "foo",
+        states: {
+          foo: {
+            on: {
+              FOO: { target: "bar", internal: false },
+            },
+          },
+          bar: {},
+        },
+      });
+    `,
+  });
+
+  const project = await createTestProject(tmpPath, { version: 'v4' });
+  expect(replaceUniqueIds(project.extractMachines('index.ts')))
+    .toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "blocks": {},
+            "data": {
+              "context": {},
+            },
+            "edges": {
+              "edge-0": {
+                "data": {
+                  "actions": [],
+                  "description": undefined,
+                  "eventTypeData": {
+                    "eventType": "FOO",
+                    "type": "named",
+                  },
+                  "guard": undefined,
+                  "internal": false,
+                  "metaEntries": [],
+                },
+                "source": "state-1",
+                "targets": [
+                  "state-2",
+                ],
+                "type": "edge",
+                "uniqueId": "edge-0",
+              },
+            },
+            "implementations": {
+              "actions": {},
+              "actors": {},
+              "guards": {},
+            },
+            "nodes": {
+              "state-0": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": "foo",
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": undefined,
+                "type": "node",
+                "uniqueId": "state-0",
+              },
+              "state-1": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-1",
+              },
+              "state-2": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-2",
+              },
+            },
+            "root": "state-0",
+          },
+          [],
+        ],
+      ]
+    `);
+});
+
+test('should extract transition with multiple targets as internal when any of its targets is defined using a descendant target by default (array of strings, v4)', async () => {
+  const tmpPath = await testdir({
+    'tsconfig.json': JSON.stringify({}),
+    'index.ts': ts`
+      import { createMachine } from "xstate";
+
+      createMachine({
+        on: {
+          MULTIPLE: {
+            target: [".a.a2", "#two"],
+          },
+        },
+        type: "parallel",
+        states: {
+          a: {
+            initial: "a1",
+            states: {
+              a1: {},
+              a2: {},
+            },
+          },
+          b: {
+            initial: "b1",
+            states: {
+              b1: {},
+              b2: {
+                id: "two",
+              },
+            },
+          },
+        },
+      });
+    `,
+  });
+
+  const project = await createTestProject(tmpPath, { version: 'v4' });
+  expect(replaceUniqueIds(project.extractMachines('index.ts')))
+    .toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "blocks": {},
+            "data": {
+              "context": {},
+            },
+            "edges": {
+              "edge-0": {
+                "data": {
+                  "actions": [],
+                  "description": undefined,
+                  "eventTypeData": {
+                    "eventType": "MULTIPLE",
+                    "type": "named",
+                  },
+                  "guard": undefined,
+                  "internal": true,
+                  "metaEntries": [],
+                },
+                "source": "state-0",
+                "targets": [
+                  "state-3",
+                  "state-6",
+                ],
+                "type": "edge",
+                "uniqueId": "edge-0",
+              },
+            },
+            "implementations": {
+              "actions": {},
+              "actors": {},
+              "guards": {},
+            },
+            "nodes": {
+              "state-0": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "parallel",
+                },
+                "parentId": undefined,
+                "type": "node",
+                "uniqueId": "state-0",
+              },
+              "state-1": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": "a1",
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-1",
+              },
+              "state-2": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-1",
+                "type": "node",
+                "uniqueId": "state-2",
+              },
+              "state-3": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-1",
+                "type": "node",
+                "uniqueId": "state-3",
+              },
+              "state-4": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": "b1",
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-4",
+              },
+              "state-5": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-4",
+                "type": "node",
+                "uniqueId": "state-5",
+              },
+              "state-6": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-4",
+                "type": "node",
+                "uniqueId": "state-6",
+              },
+            },
+            "root": "state-0",
+          },
+          [],
+        ],
+      ]
+    `);
+});
+
+test('should extract transition with multiple targets as not internal when none of its targets is defined using a descendant target by default (array of strings, v4)', async () => {
+  const tmpPath = await testdir({
+    'tsconfig.json': JSON.stringify({}),
+    'index.ts': ts`
+      import { createMachine } from "xstate";
+
+      createMachine({
+        on: {
+          MULTIPLE: {
+            target: ["#one", "#two"],
+          },
+        },
+        type: "parallel",
+        states: {
+          a: {
+            initial: "a1",
+            states: {
+              a1: {},
+              a2: {
+                id: "one",
+              },
+            },
+          },
+          b: {
+            initial: "b1",
+            states: {
+              b1: {},
+              b2: {
+                id: "two",
+              },
+            },
+          },
+        },
+      });
+    `,
+  });
+
+  const project = await createTestProject(tmpPath, { version: 'v4' });
+  expect(replaceUniqueIds(project.extractMachines('index.ts')))
+    .toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "blocks": {},
+            "data": {
+              "context": {},
+            },
+            "edges": {
+              "edge-0": {
+                "data": {
+                  "actions": [],
+                  "description": undefined,
+                  "eventTypeData": {
+                    "eventType": "MULTIPLE",
+                    "type": "named",
+                  },
+                  "guard": undefined,
+                  "internal": false,
+                  "metaEntries": [],
+                },
+                "source": "state-0",
+                "targets": [
+                  "state-3",
+                  "state-6",
+                ],
+                "type": "edge",
+                "uniqueId": "edge-0",
+              },
+            },
+            "implementations": {
+              "actions": {},
+              "actors": {},
+              "guards": {},
+            },
+            "nodes": {
+              "state-0": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "parallel",
+                },
+                "parentId": undefined,
+                "type": "node",
+                "uniqueId": "state-0",
+              },
+              "state-1": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": "a1",
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-1",
+              },
+              "state-2": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-1",
+                "type": "node",
+                "uniqueId": "state-2",
+              },
+              "state-3": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-1",
+                "type": "node",
+                "uniqueId": "state-3",
+              },
+              "state-4": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": "b1",
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-0",
+                "type": "node",
+                "uniqueId": "state-4",
+              },
+              "state-5": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-4",
+                "type": "node",
+                "uniqueId": "state-5",
+              },
+              "state-6": {
+                "data": {
+                  "description": undefined,
+                  "entry": [],
+                  "exit": [],
+                  "history": undefined,
+                  "initial": undefined,
+                  "invoke": [],
+                  "metaEntries": [],
+                  "tags": [],
+                  "type": "normal",
+                },
+                "parentId": "state-4",
+                "type": "node",
+                "uniqueId": "state-6",
+              },
+            },
+            "root": "state-0",
+          },
+          [],
+        ],
+      ]
+    `);
 });

--- a/new-packages/ts-project/__tests__/transitions.test.ts
+++ b/new-packages/ts-project/__tests__/transitions.test.ts
@@ -5062,7 +5062,7 @@ test('should extract a sibling transition as not internal by default (direct str
     `,
   });
 
-  const project = await createTestProject(tmpPath, { version: 'v4' });
+  const project = await createTestProject(tmpPath, { xstateVersion: '4' });
   expect(replaceUniqueIds(project.extractMachines('index.ts')))
     .toMatchInlineSnapshot(`
       [
@@ -5178,7 +5178,7 @@ test('should extract a descendant transition as internal by default (direct stri
     `,
   });
 
-  const project = await createTestProject(tmpPath, { version: 'v4' });
+  const project = await createTestProject(tmpPath, { xstateVersion: '4' });
   expect(replaceUniqueIds(project.extractMachines('index.ts')))
     .toMatchInlineSnapshot(`
       [
@@ -5292,7 +5292,7 @@ test('should extract a sibling transition as internal by default (direct object 
     `,
   });
 
-  const project = await createTestProject(tmpPath, { version: 'v4' });
+  const project = await createTestProject(tmpPath, { xstateVersion: '4' });
   expect(replaceUniqueIds(project.extractMachines('index.ts')))
     .toMatchInlineSnapshot(`
       [
@@ -5410,7 +5410,7 @@ test('should extract a descendant transition as internal by default (direct obje
     `,
   });
 
-  const project = await createTestProject(tmpPath, { version: 'v4' });
+  const project = await createTestProject(tmpPath, { xstateVersion: '4' });
   expect(replaceUniqueIds(project.extractMachines('index.ts')))
     .toMatchInlineSnapshot(`
       [
@@ -5524,7 +5524,7 @@ test('should extract an explicit internal transition as internal (v4)', async ()
     `,
   });
 
-  const project = await createTestProject(tmpPath, { version: 'v4' });
+  const project = await createTestProject(tmpPath, { xstateVersion: '4' });
   expect(replaceUniqueIds(project.extractMachines('index.ts')))
     .toMatchInlineSnapshot(`
       [
@@ -5638,7 +5638,7 @@ test('should extract an explicit non-internal transition as not internal (v4)', 
     `,
   });
 
-  const project = await createTestProject(tmpPath, { version: 'v4' });
+  const project = await createTestProject(tmpPath, { xstateVersion: '4' });
   expect(replaceUniqueIds(project.extractMachines('index.ts')))
     .toMatchInlineSnapshot(`
       [
@@ -5767,7 +5767,7 @@ test('should extract transition with multiple targets as internal when any of it
     `,
   });
 
-  const project = await createTestProject(tmpPath, { version: 'v4' });
+  const project = await createTestProject(tmpPath, { xstateVersion: '4' });
   expect(replaceUniqueIds(project.extractMachines('index.ts')))
     .toMatchInlineSnapshot(`
       [
@@ -5963,7 +5963,7 @@ test('should extract transition with multiple targets as not internal when none 
     `,
   });
 
-  const project = await createTestProject(tmpPath, { version: 'v4' });
+  const project = await createTestProject(tmpPath, { xstateVersion: '4' });
   expect(replaceUniqueIds(project.extractMachines('index.ts')))
     .toMatchInlineSnapshot(`
       [

--- a/new-packages/ts-project/__tests__/utils.ts
+++ b/new-packages/ts-project/__tests__/utils.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import { onExit } from 'signal-exit';
 import { temporaryDirectory } from 'tempy';
 import typescript from 'typescript';
-import { XStateProject, createProject } from '../src/index';
+import { TSProjectOptions, XStateProject, createProject } from '../src/index';
 import { ActorBlock } from '../src/types';
 
 export const js = outdent;
@@ -105,13 +105,17 @@ async function createTestProgram(
 
 export async function createTestProject(
   cwd: string,
-  { ts = typescript, ...options }: Partial<TypeScriptTestProgramOptions> = {},
+  {
+    ts = typescript,
+    version,
+    ...options
+  }: Partial<TypeScriptTestProgramOptions & TSProjectOptions> = {},
 ) {
   const program = await createTestProgram(cwd, {
     ts: typescript,
     ...options,
   });
-  return createProject(ts, program);
+  return createProject(ts, program, { version });
 }
 
 function replaceUniqueIdsRecursively(

--- a/new-packages/ts-project/__tests__/utils.ts
+++ b/new-packages/ts-project/__tests__/utils.ts
@@ -107,7 +107,7 @@ export async function createTestProject(
   cwd: string,
   {
     ts = typescript,
-    version,
+    xstateVersion: version,
     ...options
   }: Partial<TypeScriptTestProgramOptions & TSProjectOptions> = {},
 ) {
@@ -115,7 +115,7 @@ export async function createTestProject(
     ts: typescript,
     ...options,
   });
-  return createProject(ts, program, { version });
+  return createProject(ts, program, { xstateVersion: version });
 }
 
 function replaceUniqueIdsRecursively(

--- a/new-packages/ts-project/src/index.ts
+++ b/new-packages/ts-project/src/index.ts
@@ -5,6 +5,7 @@ import {
   ExtractionError,
   ExtractorDigraphDef,
   TreeNode,
+  XStateVersion,
 } from './types';
 
 function findCreateMachineCalls(
@@ -104,31 +105,10 @@ function resolveTargets(ctx: ExtractionContext) {
 }
 
 function extractMachineConfig(
+  ctx: ExtractionContext,
   ts: typeof import('typescript'),
   createMachineCall: CallExpression,
-  sourceFile: SourceFile,
 ): readonly [ExtractorDigraphDef | undefined, ExtractionError[]] {
-  const ctx: ExtractionContext = {
-    sourceFile,
-    errors: [],
-    digraph: {
-      nodes: {},
-      edges: {},
-      blocks: {},
-      implementations: {
-        actions: {},
-        actors: {},
-        guards: {},
-      },
-      data: {
-        context: {},
-      },
-    },
-    treeNodes: {},
-    idMap: {},
-    originalTargets: {},
-  };
-
   const rootState = createMachineCall.arguments[0];
   const rootNode = extractState(ctx, ts, rootState, undefined);
 
@@ -154,6 +134,7 @@ function extractMachineConfig(
 export function createProject(
   ts: typeof import('typescript'),
   tsProgram: Program,
+  { version = 'v5' }: { version?: XStateVersion },
 ) {
   return {
     extractMachines(fileName: string) {
@@ -162,7 +143,28 @@ export function createProject(
         return [];
       }
       return findCreateMachineCalls(ts, sourceFile).map((call) => {
-        return extractMachineConfig(ts, call, sourceFile);
+        const ctx: ExtractionContext = {
+          sourceFile,
+          version,
+          errors: [],
+          digraph: {
+            nodes: {},
+            edges: {},
+            blocks: {},
+            implementations: {
+              actions: {},
+              actors: {},
+              guards: {},
+            },
+            data: {
+              context: {},
+            },
+          },
+          treeNodes: {},
+          idMap: {},
+          originalTargets: {},
+        };
+        return extractMachineConfig(ctx, ts, call);
       });
     },
   };

--- a/new-packages/ts-project/src/index.ts
+++ b/new-packages/ts-project/src/index.ts
@@ -132,13 +132,13 @@ function extractMachineConfig(
 }
 
 export interface TSProjectOptions {
-  version?: XStateVersion | undefined;
+  xstateVersion?: XStateVersion | undefined;
 }
 
 export function createProject(
   ts: typeof import('typescript'),
   tsProgram: Program,
-  { version = 'v5' }: TSProjectOptions = {},
+  { xstateVersion = '5' }: TSProjectOptions = {},
 ) {
   return {
     extractMachines(fileName: string) {
@@ -149,7 +149,7 @@ export function createProject(
       return findCreateMachineCalls(ts, sourceFile).map((call) => {
         const ctx: ExtractionContext = {
           sourceFile,
-          version,
+          xstateVersion,
           errors: [],
           digraph: {
             nodes: {},

--- a/new-packages/ts-project/src/index.ts
+++ b/new-packages/ts-project/src/index.ts
@@ -131,10 +131,14 @@ function extractMachineConfig(
   ];
 }
 
+export interface TSProjectOptions {
+  version?: XStateVersion | undefined;
+}
+
 export function createProject(
   ts: typeof import('typescript'),
   tsProgram: Program,
-  { version = 'v5' }: { version?: XStateVersion },
+  { version = 'v5' }: TSProjectOptions = {},
 ) {
   return {
     extractMachines(fileName: string) {

--- a/new-packages/ts-project/src/types.ts
+++ b/new-packages/ts-project/src/types.ts
@@ -1,5 +1,8 @@
 import type { SourceFile } from 'typescript';
 
+// it's acting as a threshold - atm there is no need to know the exact version
+export type XStateVersion = 'v4' | 'v5';
+
 export interface TreeNode {
   uniqueId: string;
   parentId: string | undefined;
@@ -8,6 +11,7 @@ export interface TreeNode {
 
 export interface ExtractionContext {
   sourceFile: SourceFile;
+  version: XStateVersion;
   errors: ExtractionError[];
   digraph: Pick<
     ExtractorDigraphDef,

--- a/new-packages/ts-project/src/types.ts
+++ b/new-packages/ts-project/src/types.ts
@@ -1,7 +1,8 @@
 import type { SourceFile } from 'typescript';
 
 // it's acting as a threshold - atm there is no need to know the exact version
-export type XStateVersion = 'v4' | 'v5';
+// strings are used to allow for future minor versions
+export type XStateVersion = '4' | '5';
 
 export interface TreeNode {
   uniqueId: string;
@@ -11,7 +12,7 @@ export interface TreeNode {
 
 export interface ExtractionContext {
   sourceFile: SourceFile;
-  version: XStateVersion;
+  xstateVersion: XStateVersion;
   errors: ExtractionError[];
   digraph: Pick<
     ExtractorDigraphDef,


### PR DESCRIPTION
tbh, it's hard to tell how it will **exactly** work with the Studio since it permits `undefined`. On top of that, it's not completely obvious how this property "evolves" when reanchoring transitions. For many transitions this property doesn't matter (only transitions that target descendants differ in behavior based on this property). I think we'll have to learn in practice how this plays out and tweak things if needed